### PR TITLE
feat(ingestkit-excel): Implement Path A structured DB processor (#8)

### DIFF
--- a/.agents/outputs/map-8-021026.md
+++ b/.agents/outputs/map-8-021026.md
@@ -1,0 +1,814 @@
+# MAP Artifact: Issue #8 -- Path A Structured DB Processor
+
+**Issue:** #8
+**Date:** 2026-02-11
+**Target file:** `src/ingestkit_excel/processors/structured_db.py` (NEW)
+**Also needed:** `src/ingestkit_excel/processors/__init__.py` (NEW)
+**Spec reference:** SPEC.md section 10.1 (Path A -- Structured DB Processor)
+
+---
+
+## 1. Enum Values Reference
+
+All enum values are the **string values** (not Python names). Use these exact strings when constructing metadata and results.
+
+### IngestionMethod (models.py line 48-57)
+| Python Name | String Value | Context |
+|---|---|---|
+| `SQL_AGENT` | `"sql_agent"` | **Path A -- this processor** |
+| `TEXT_SERIALIZATION` | `"text_serialization"` | Path B |
+| `HYBRID_SPLIT` | `"hybrid_split"` | Path C |
+
+**CRITICAL ENUM_VALUE:** Use `IngestionMethod.SQL_AGENT` (Python) or `"sql_agent"` (string). **NEVER** `"SQL_AGENT"`.
+
+### ParserUsed (models.py line 72-77)
+| Python Name | String Value |
+|---|---|
+| `OPENPYXL` | `"openpyxl"` |
+| `PANDAS_FALLBACK` | `"pandas_fallback"` |
+| `RAW_TEXT_FALLBACK` | `"raw_text_fallback"` |
+
+### FileType (models.py line 24-32)
+| Python Name | String Value |
+|---|---|
+| `TABULAR_DATA` | `"tabular_data"` |
+| `FORMATTED_DOCUMENT` | `"formatted_document"` |
+| `HYBRID` | `"hybrid"` |
+
+### ClassificationTier (models.py line 36-45)
+| Python Name | String Value |
+|---|---|
+| `RULE_BASED` | `"rule_based"` |
+| `LLM_BASIC` | `"llm_basic"` |
+| `LLM_REASONING` | `"llm_reasoning"` |
+
+### ErrorCode -- Path A Relevant (errors.py)
+| Python Name | String Value | When Used |
+|---|---|---|
+| `E_BACKEND_DB_TIMEOUT` | `"E_BACKEND_DB_TIMEOUT"` | StructuredDBBackend timeout |
+| `E_BACKEND_DB_CONNECT` | `"E_BACKEND_DB_CONNECT"` | StructuredDBBackend connection failure |
+| `E_BACKEND_VECTOR_TIMEOUT` | `"E_BACKEND_VECTOR_TIMEOUT"` | VectorStoreBackend timeout |
+| `E_BACKEND_VECTOR_CONNECT` | `"E_BACKEND_VECTOR_CONNECT"` | VectorStoreBackend connection failure |
+| `E_BACKEND_EMBED_TIMEOUT` | `"E_BACKEND_EMBED_TIMEOUT"` | EmbeddingBackend timeout |
+| `E_BACKEND_EMBED_CONNECT` | `"E_BACKEND_EMBED_CONNECT"` | EmbeddingBackend connection failure |
+| `E_PROCESS_SCHEMA_GEN` | `"E_PROCESS_SCHEMA_GEN"` | Schema description generation failed |
+| `W_SHEET_SKIPPED_CHART` | `"W_SHEET_SKIPPED_CHART"` | Chart-only sheet skipped |
+| `W_SHEET_SKIPPED_HIDDEN` | `"W_SHEET_SKIPPED_HIDDEN"` | Hidden sheet skipped |
+| `W_SHEET_SKIPPED_PASSWORD` | `"W_SHEET_SKIPPED_PASSWORD"` | Password-protected sheet skipped |
+| `W_ROWS_TRUNCATED` | `"W_ROWS_TRUNCATED"` | Sheet exceeds max_rows_in_memory |
+| `W_PARSER_FALLBACK` | `"W_PARSER_FALLBACK"` | Fallback parser used |
+
+---
+
+## 2. Model Field Reference
+
+### ChunkMetadata (models.py lines 195-219) -- ALL FIELDS
+
+```python
+class ChunkMetadata(BaseModel):
+    # Shared across all paths
+    source_uri: str                    # canonical file path or URI
+    source_format: str = "xlsx"        # always "xlsx" for this package
+    sheet_name: str                    # worksheet name
+    region_id: str | None = None       # for hybrid splits (Path C only, None for Path A)
+    ingestion_method: str              # IngestionMethod VALUE string, e.g. "sql_agent"
+    parser_used: str                   # ParserUsed VALUE string, e.g. "openpyxl"
+    parser_version: str                # e.g. "ingestkit_excel:1.0.0"
+    chunk_index: int                   # 0-based position within this source
+    chunk_hash: str                    # SHA-256 of chunk text
+    ingest_key: str                    # idempotency key (from IngestKey.key property)
+    ingest_run_id: str                 # UUID4, unique per process() invocation
+    tenant_id: str | None = None       # from config
+
+    # Path A specific -- THESE ARE THE FIELDS WE MUST POPULATE
+    table_name: str | None = None      # cleaned table name written to DB
+    db_uri: str | None = None          # connection URI from structured_db.get_connection_uri()
+    row_count: int | None = None       # number of rows in the table
+    columns: list[str] | None = None   # list of cleaned column names
+
+    # Path B specific -- set to None for Path A
+    section_title: str | None = None
+    original_structure: str | None = None
+```
+
+### ChunkPayload (models.py lines 222-228)
+
+```python
+class ChunkPayload(BaseModel):
+    id: str                # deterministic UUID from chunk_hash + ingest_key
+    text: str              # the text content (schema description or serialized row)
+    vector: list[float]    # embedding vector
+    metadata: ChunkMetadata
+```
+
+### WrittenArtifacts (models.py lines 245-250)
+
+```python
+class WrittenArtifacts(BaseModel):
+    vector_point_ids: list[str] = []       # IDs upserted to vector store
+    vector_collection: str | None = None   # collection name used
+    db_table_names: list[str] = []         # table names created in structured DB
+```
+
+### ProcessingResult (models.py lines 253-277)
+
+```python
+class ProcessingResult(BaseModel):
+    file_path: str
+    ingest_key: str                        # idempotency key
+    ingest_run_id: str                     # unique per invocation
+    tenant_id: str | None = None
+
+    # Stage artifacts (typed, persisted)
+    parse_result: ParseStageResult
+    classification_result: ClassificationStageResult
+    embed_result: EmbedStageResult | None = None  # populated by this processor
+
+    # Legacy convenience fields
+    classification: ClassificationResult
+    ingestion_method: IngestionMethod      # = IngestionMethod.SQL_AGENT for Path A
+
+    # Outputs
+    chunks_created: int                    # total chunks upserted to vector store
+    tables_created: int                    # tables written to structured DB
+    tables: list[str]                      # table name list
+    written: WrittenArtifacts              # for caller-side rollback
+
+    # Errors and warnings
+    errors: list[str]                      # list of ErrorCode VALUE strings
+    warnings: list[str]                    # list of ErrorCode VALUE strings
+    error_details: list[IngestError] = []  # structured error objects
+
+    processing_time_seconds: float
+```
+
+### ParseStageResult (models.py lines 112-120)
+
+```python
+class ParseStageResult(BaseModel):
+    parser_used: ParserUsed
+    fallback_reason_code: str | None = None
+    sheets_parsed: int
+    sheets_skipped: int
+    skipped_reasons: dict[str, str]       # {sheet_name: reason_code}
+    parse_duration_seconds: float
+```
+
+### ClassificationStageResult (models.py lines 123-132)
+
+```python
+class ClassificationStageResult(BaseModel):
+    tier_used: ClassificationTier
+    file_type: FileType
+    confidence: float
+    signals: dict[str, Any] | None = None
+    reasoning: str
+    per_sheet_types: dict[str, FileType] | None = None
+    classification_duration_seconds: float
+```
+
+### EmbedStageResult (models.py lines 135-140)
+
+```python
+class EmbedStageResult(BaseModel):
+    texts_embedded: int            # total texts embedded
+    embedding_dimension: int       # dimension of vectors
+    embed_duration_seconds: float
+```
+
+### SheetProfile (models.py lines 148-166) -- Input to processor
+
+```python
+class SheetProfile(BaseModel):
+    name: str
+    row_count: int
+    col_count: int
+    merged_cell_count: int
+    merged_cell_ratio: float
+    header_row_detected: bool
+    header_row_index: int | None = None    # NOTE: actual code has this field (not in spec)
+    header_values: list[str]
+    column_type_consistency: float
+    numeric_ratio: float
+    text_ratio: float
+    empty_ratio: float
+    sample_rows: list[list[str]]
+    has_formulas: bool
+    is_hidden: bool
+    parser_used: ParserUsed
+```
+
+### FileProfile (models.py lines 169-181) -- Input to processor
+
+```python
+class FileProfile(BaseModel):
+    file_path: str
+    file_size_bytes: int
+    sheet_count: int
+    sheet_names: list[str]
+    sheets: list[SheetProfile]
+    has_password_protected_sheets: bool
+    has_chart_only_sheets: bool
+    total_merged_cells: int
+    total_rows: int
+    content_hash: str
+```
+
+### IngestError (errors.py lines 55-67)
+
+```python
+class IngestError(BaseModel):
+    code: ErrorCode
+    message: str
+    sheet_name: str | None = None
+    stage: str | None = None          # "parse", "classify", "process", "embed"
+    recoverable: bool = False
+```
+
+---
+
+## 3. Config Field Reference -- Processor-Relevant Fields
+
+From `ExcelProcessorConfig` (config.py):
+
+| Field | Type | Default | Usage in Path A |
+|---|---|---|---|
+| `parser_version` | `str` | `"ingestkit_excel:1.0.0"` | ChunkMetadata.parser_version |
+| `tenant_id` | `str \| None` | `None` | ChunkMetadata.tenant_id, ProcessingResult.tenant_id |
+| `row_serialization_limit` | `int` | `5000` | Only serialize rows if table has FEWER than this many rows |
+| `clean_column_names` | `bool` | `True` | Whether to clean column names (lowercase, special char replace, dedup) |
+| `embedding_model` | `str` | `"nomic-embed-text"` | Model name (informational, passed through to embedder) |
+| `embedding_dimension` | `int` | `768` | For EmbedStageResult and ensure_collection vector_size |
+| `embedding_batch_size` | `int` | `64` | Batch size when calling embedder.embed() |
+| `default_collection` | `str` | `"helpdesk"` | Vector store collection name |
+| `backend_timeout_seconds` | `float` | `30.0` | Timeout for backend calls |
+| `backend_max_retries` | `int` | `2` | Max retries for backend calls |
+| `backend_backoff_base` | `float` | `1.0` | Base seconds for exponential backoff |
+| `max_rows_in_memory` | `int` | `100_000` | Sheets exceeding this are skipped |
+| `log_sample_data` | `bool` | `False` | Whether to log sample data |
+| `log_chunk_previews` | `bool` | `False` | Whether to log chunk text |
+
+---
+
+## 4. Protocol Reference -- Exact Method Signatures
+
+### StructuredDBBackend (protocols.py lines 40-59)
+
+```python
+@runtime_checkable
+class StructuredDBBackend(Protocol):
+    def create_table_from_dataframe(self, table_name: str, df: pd.DataFrame) -> None: ...
+    def drop_table(self, table_name: str) -> None: ...
+    def table_exists(self, table_name: str) -> bool: ...
+    def get_table_schema(self, table_name: str) -> dict: ...
+    def get_connection_uri(self) -> str: ...
+```
+
+**Usage in Path A:**
+- `create_table_from_dataframe(table_name, df)` -- Step 4: write each sheet as a table
+- `get_connection_uri()` -- for `ChunkMetadata.db_uri`
+- `get_table_schema(table_name)` -- for schema description generation (Step 5)
+
+### VectorStoreBackend (protocols.py lines 19-36)
+
+```python
+@runtime_checkable
+class VectorStoreBackend(Protocol):
+    def upsert_chunks(self, collection: str, chunks: list[ChunkPayload]) -> int: ...
+    def ensure_collection(self, collection: str, vector_size: int) -> None: ...
+    def create_payload_index(self, collection: str, field: str, field_type: str) -> None: ...
+    def delete_by_ids(self, collection: str, ids: list[str]) -> int: ...
+```
+
+**Usage in Path A:**
+- `ensure_collection(config.default_collection, config.embedding_dimension)` -- ensure collection exists
+- `upsert_chunks(collection, chunks)` -- Step 6: upsert schema description chunks (and optional row chunks)
+
+### EmbeddingBackend (protocols.py lines 89-101)
+
+```python
+@runtime_checkable
+class EmbeddingBackend(Protocol):
+    def embed(self, texts: list[str], timeout: float | None = None) -> list[list[float]]: ...
+    def dimension(self) -> int: ...
+```
+
+**Usage in Path A:**
+- `embed(texts, timeout)` -- Step 6: embed schema descriptions; Step 7: embed row serializations
+- `dimension()` -- for EmbedStageResult.embedding_dimension and ensure_collection vector_size
+
+---
+
+## 5. SPEC section 10.1 -- All 7 Processing Steps
+
+### Step 1: Load each sheet into a pandas DataFrame
+
+- Iterate over `profile.sheets` (list of `SheetProfile`)
+- For each sheet, load via `pd.read_excel(file_path, sheet_name=sheet.name)`
+- Use `header=sheet.header_row_index` if header was detected, otherwise `header=None`
+- Skip sheets that are chart-only, hidden (if config says so), or exceed row limits
+- The DataFrame is the working data for all subsequent steps
+
+### Step 2: Clean column names
+
+- **Only if `config.clean_column_names` is True**
+- Rules:
+  1. Convert to lowercase: `col.lower()`
+  2. Replace spaces and special characters with underscores: `re.sub(r'[^a-z0-9_]', '_', col)`
+  3. Collapse multiple consecutive underscores: `re.sub(r'_+', '_', col)`
+  4. Strip leading/trailing underscores: `col.strip('_')`
+  5. Deduplicate column names: if duplicates exist after cleaning, append `_1`, `_2`, etc.
+  6. If column name becomes empty after cleaning, use `column_N` (0-based index)
+- Apply to DataFrame: `df.columns = cleaned_columns`
+
+### Step 3: Auto-detect and parse date columns
+
+- Detect date columns by two patterns:
+  1. **Excel serial dates**: numeric columns where values are plausible date serials (e.g., 40000-50000 range, representing ~2009-2036). Convert via `pd.to_datetime(col, origin='1899-12-30', unit='D')`
+  2. **String dates**: text columns where values parse successfully as dates. Use `pd.to_datetime(col, infer_datetime_format=True, errors='coerce')`. If a high proportion (e.g., >50%) parse successfully, convert the column.
+- **Important**: Be conservative. Only convert when confident to avoid corrupting numeric data.
+
+### Step 4: Write each sheet as a table to StructuredDBBackend
+
+- Derive table name from sheet name using same cleaning rules as column names (lowercase, special chars to underscores, dedup)
+- Call `structured_db.create_table_from_dataframe(table_name, df)`
+- Track table name in `WrittenArtifacts.db_table_names`
+
+### Step 5: Generate natural language schema description per table
+
+- Format (from SPEC):
+  ```
+  Table "employee_roster" contains 342 rows with columns:
+  - employee_id (integer): unique identifier, range 10042-10943
+  - full_name (text): employee name
+  - department (text): one of Engineering, Sales, HR, Finance, ...
+  - hire_date (date): ranges from 2018-01-15 to 2024-11-30
+  - salary (float): ranges from 45000.0 to 185000.0
+  ```
+- For each column, describe:
+  - Column name and inferred type (integer, float, text, date, boolean)
+  - For numeric columns: range (min to max)
+  - For text columns: if cardinality is low (< ~20 unique), list the unique values; otherwise say "N unique values"
+  - For date columns: range (earliest to latest)
+- This description becomes the chunk text for embedding
+
+### Step 6: Embed schema description and upsert to VectorStoreBackend
+
+- Ensure collection exists: `vector_store.ensure_collection(collection, vector_size)`
+- Embed the schema description text: `embedder.embed([schema_text])`
+- Construct `ChunkMetadata` with all Path A fields populated
+- Construct `ChunkPayload` with deterministic ID
+- Upsert: `vector_store.upsert_chunks(collection, [chunk])`
+- Track point IDs in `WrittenArtifacts.vector_point_ids`
+- Track collection in `WrittenArtifacts.vector_collection`
+
+### Step 7: Optional row serialization
+
+- **Condition**: Only if table row count < `config.row_serialization_limit` (default: 5000)
+- Convert each row to a natural language sentence
+- Format: `"In table '{table_name}', row {i}: {col1} is {val1}, {col2} is {val2}, ..."` (or similar)
+- Embed in batches of `config.embedding_batch_size`
+- Upsert as individual chunks, each with its own `ChunkMetadata` (incrementing `chunk_index`)
+- Track all point IDs in `WrittenArtifacts.vector_point_ids`
+
+---
+
+## 6. Column Cleaning Rules -- Detailed
+
+The cleaning logic for column names (Step 2) must also be applied to derive table names from sheet names (Step 4).
+
+```python
+import re
+
+def clean_name(raw: str) -> str:
+    """Clean a raw name (column or sheet) for use as a DB identifier."""
+    name = raw.lower()
+    name = re.sub(r'[^a-z0-9_]', '_', name)
+    name = re.sub(r'_+', '_', name)
+    name = name.strip('_')
+    return name
+
+def deduplicate_names(names: list[str]) -> list[str]:
+    """Deduplicate a list of cleaned names by appending _1, _2, etc."""
+    seen: dict[str, int] = {}
+    result: list[str] = []
+    for i, name in enumerate(names):
+        if not name:
+            name = f"column_{i}"
+        if name in seen:
+            seen[name] += 1
+            result.append(f"{name}_{seen[name]}")
+        else:
+            seen[name] = 0
+            result.append(name)
+    return result
+```
+
+---
+
+## 7. Date Parsing Rules -- Detailed
+
+### Excel Serial Dates
+- Excel stores dates as floating-point numbers: days since 1899-12-30
+- Typical range for modern dates: ~40000 (2009) to ~50000 (2036)
+- Detection heuristic: column is numeric, all values in a plausible serial date range
+- Conversion: `pd.to_datetime(series, origin='1899-12-30', unit='D')`
+
+### String Dates
+- Text columns that contain date-like strings
+- Detection: try `pd.to_datetime(series, infer_datetime_format=True, errors='coerce')`
+- If >= 50% of non-null values successfully parse, convert the column
+- Be conservative to avoid converting IDs or codes that happen to look like dates
+
+### Important Notes
+- Date detection should happen AFTER column cleaning but BEFORE writing to DB
+- Only convert columns where there's high confidence (to avoid data corruption)
+- Log date conversions at DEBUG level for traceability
+
+---
+
+## 8. Schema Description Format -- Detailed
+
+The schema description is a natural language text chunk that will be embedded for semantic search. It serves as the bridge between SQL tables and the vector store -- when a user asks a question, the schema description helps the system identify which table to query.
+
+### Format Template
+
+```
+Table "{table_name}" contains {row_count} rows with columns:
+- {col_name} ({col_type}): {description}
+- {col_name} ({col_type}): {description}
+...
+```
+
+### Column Type Mapping
+
+| pandas dtype | Schema type string |
+|---|---|
+| `int64`, `int32`, etc. | `"integer"` |
+| `float64`, `float32`, etc. | `"float"` |
+| `object` (string) | `"text"` |
+| `datetime64[ns]` | `"date"` |
+| `bool` | `"boolean"` |
+| other | `"text"` (fallback) |
+
+### Column Description Generation
+
+- **Integer/Float columns**: `"range {min} to {max}"` -- e.g., `"range 10042 to 10943"`
+- **Text columns (low cardinality, <20 unique)**: `"one of {val1}, {val2}, {val3}, ..."` -- e.g., `"one of Engineering, Sales, HR, Finance"`
+- **Text columns (high cardinality, >=20 unique)**: `"{N} unique values"` -- e.g., `"342 unique values"`
+- **Date columns**: `"ranges from {earliest} to {latest}"` -- e.g., `"ranges from 2018-01-15 to 2024-11-30"`
+- **Boolean columns**: `"true/false"`
+
+---
+
+## 9. ChunkMetadata Assembly -- Exact Field Sources
+
+For the **schema description chunk** (one per table):
+
+| ChunkMetadata field | Value source |
+|---|---|
+| `source_uri` | Passed as parameter (from router, canonical file path, e.g. `"file:///path/to/file.xlsx"`) |
+| `source_format` | `"xlsx"` (default) |
+| `sheet_name` | `sheet_profile.name` |
+| `region_id` | `None` (Path A does not use regions) |
+| `ingestion_method` | `"sql_agent"` (the string VALUE of `IngestionMethod.SQL_AGENT`) |
+| `parser_used` | `sheet_profile.parser_used.value` (e.g. `"openpyxl"`) |
+| `parser_version` | `config.parser_version` (e.g. `"ingestkit_excel:1.0.0"`) |
+| `chunk_index` | `0` for schema chunk; increments for row serialization chunks |
+| `chunk_hash` | `hashlib.sha256(text.encode()).hexdigest()` |
+| `ingest_key` | Passed as parameter (from `IngestKey.key` property, a SHA-256 hex string) |
+| `ingest_run_id` | Passed as parameter (UUID4 string from router) |
+| `tenant_id` | `config.tenant_id` |
+| `table_name` | Cleaned table name derived from sheet name |
+| `db_uri` | `structured_db.get_connection_uri()` |
+| `row_count` | `len(df)` |
+| `columns` | Cleaned column name list |
+| `section_title` | `None` (Path B only) |
+| `original_structure` | `None` (Path B only) |
+
+### ChunkPayload.id Generation
+
+The `id` field must be deterministic for idempotency:
+```python
+import hashlib
+raw = f"{chunk_hash}:{ingest_key}"
+chunk_id = hashlib.sha256(raw.encode()).hexdigest()
+```
+
+Or use `uuid5` with a namespace derived from `ingest_key`:
+```python
+import uuid
+chunk_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{ingest_key}:{chunk_hash}"))
+```
+
+---
+
+## 10. Row Serialization -- Detailed
+
+### When Triggered
+- Only when `len(df) < config.row_serialization_limit` (default: 5000)
+- This is a per-table decision (some tables may serialize, others may not)
+
+### Format
+Each row becomes a natural language sentence:
+```
+In table '{table_name}', row {row_number}: {col1} is {val1}, {col2} is {val2}, {col3} is {val3}.
+```
+
+Example:
+```
+In table 'employee_roster', row 1: employee_id is 10042, full_name is John Smith, department is Engineering, hire_date is 2020-03-15, salary is 95000.0.
+```
+
+### Chunking Strategy
+- Each row is an individual chunk
+- `chunk_index` continues from where schema description chunks left off
+- Each row chunk gets its own `chunk_hash` based on its text content
+- Embed in batches using `config.embedding_batch_size` (default: 64)
+
+### ChunkMetadata for Row Chunks
+- Same as schema description chunk EXCEPT:
+  - `chunk_index`: incremented per row (starting after schema chunk)
+  - `chunk_hash`: SHA-256 of the row text
+  - `text`: the serialized row text
+
+---
+
+## 11. WrittenArtifacts Tracking -- For Rollback
+
+The processor must carefully track everything it writes so the caller can roll back.
+
+### What Gets Tracked
+
+```python
+written = WrittenArtifacts(
+    vector_point_ids=[...],       # ALL chunk IDs upserted to vector store
+    vector_collection="helpdesk", # config.default_collection
+    db_table_names=[...],         # ALL table names created in structured DB
+)
+```
+
+### Tracking Points
+1. After `create_table_from_dataframe()` succeeds: append table_name to `db_table_names`
+2. After `upsert_chunks()` succeeds: extend `vector_point_ids` with all chunk IDs
+3. Set `vector_collection` to `config.default_collection`
+
+### Rollback Contract (caller-side, not implemented in processor)
+```python
+# Caller uses WrittenArtifacts to undo:
+vector_store.delete_by_ids(written.vector_collection, written.vector_point_ids)
+for table in written.db_table_names:
+    structured_db.drop_table(table)
+```
+
+---
+
+## 12. Dependency Map -- All Imports Needed
+
+### Standard Library
+```python
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import time
+import uuid
+from typing import TYPE_CHECKING
+```
+
+### Third-Party
+```python
+import pandas as pd
+```
+
+### Internal
+```python
+from ingestkit_excel.config import ExcelProcessorConfig
+from ingestkit_excel.errors import ErrorCode, IngestError
+from ingestkit_excel.models import (
+    ChunkMetadata,
+    ChunkPayload,
+    ClassificationResult,
+    ClassificationStageResult,
+    EmbedStageResult,
+    FileProfile,
+    IngestionMethod,
+    ParseStageResult,
+    ProcessingResult,
+    WrittenArtifacts,
+)
+```
+
+### TYPE_CHECKING Only (for Protocol references)
+```python
+if TYPE_CHECKING:
+    from ingestkit_excel.protocols import (
+        EmbeddingBackend,
+        StructuredDBBackend,
+        VectorStoreBackend,
+    )
+```
+
+**Note**: Do NOT import protocols at runtime to avoid circular imports. The constructor takes them as parameters with runtime type hints.
+
+### Actual Constructor Type Hints
+
+Since protocols use `runtime_checkable`, you can import them directly (they are not in a circular path with the processor):
+
+```python
+from ingestkit_excel.protocols import (
+    EmbeddingBackend,
+    StructuredDBBackend,
+    VectorStoreBackend,
+)
+```
+
+The import chain is: `protocols.py` imports `ChunkPayload` only under `TYPE_CHECKING`, so there is NO circular import risk for the processor module.
+
+---
+
+## 13. Risk Flags
+
+### ENUM_VALUE Risk
+
+| Location | Risk | Prevention |
+|---|---|---|
+| `ChunkMetadata.ingestion_method` | Must be `"sql_agent"` not `"SQL_AGENT"` | Use `IngestionMethod.SQL_AGENT.value` or the literal string `"sql_agent"` |
+| `ChunkMetadata.parser_used` | Must be `"openpyxl"` not `"OPENPYXL"` | Use `sheet_profile.parser_used.value` |
+| `ProcessingResult.ingestion_method` | Must be `IngestionMethod.SQL_AGENT` (the enum member) | Use `IngestionMethod.SQL_AGENT` directly |
+| `ProcessingResult.errors` / `warnings` | Must be ErrorCode VALUE strings | Use `ErrorCode.E_BACKEND_DB_TIMEOUT.value` |
+
+### VERIFICATION_GAP Risk
+
+| Assumption | Must Verify |
+|---|---|
+| SheetProfile has `header_row_index` field | VERIFIED: models.py line 157 -- `header_row_index: int \| None = None` |
+| FileProfile has `content_hash` field | VERIFIED: models.py line 181 -- `content_hash: str` |
+| ProcessingResult accepts `embed_result` as optional | VERIFIED: models.py line 263 -- `embed_result: EmbedStageResult \| None = None` |
+| `StructuredDBBackend.get_connection_uri()` returns `str` | VERIFIED: protocols.py line 59 |
+| `EmbeddingBackend.embed()` returns `list[list[float]]` | VERIFIED: protocols.py line 93-95 |
+| `VectorStoreBackend.upsert_chunks()` returns `int` (count) | VERIFIED: protocols.py line 22 |
+| `WrittenArtifacts.vector_point_ids` is `list[str]` | VERIFIED: models.py line 248 |
+| `WrittenArtifacts.db_table_names` is `list[str]` | VERIFIED: models.py line 250 |
+| `ProcessingResult` requires `parse_result` and `classification_result` | VERIFIED: models.py lines 261-262 -- both are required (no default) |
+| Config field `row_serialization_limit` default is 5000 | VERIFIED: config.py line 44 |
+
+### COMPONENT_API Risk
+
+| Component | Must-Use Signature |
+|---|---|
+| `structured_db.create_table_from_dataframe(table_name: str, df: pd.DataFrame) -> None` | Exact |
+| `structured_db.get_connection_uri() -> str` | Exact |
+| `vector_store.ensure_collection(collection: str, vector_size: int) -> None` | Exact |
+| `vector_store.upsert_chunks(collection: str, chunks: list[ChunkPayload]) -> int` | Exact |
+| `embedder.embed(texts: list[str], timeout: float \| None = None) -> list[list[float]]` | Exact |
+| `embedder.dimension() -> int` | Exact |
+
+---
+
+## 14. Public Interface (from SPEC)
+
+```python
+class StructuredDBProcessor:
+    def __init__(
+        self,
+        structured_db: StructuredDBBackend,
+        vector_store: VectorStoreBackend,
+        embedder: EmbeddingBackend,
+        config: ExcelProcessorConfig,
+    ) -> None: ...
+
+    def process(
+        self,
+        file_path: str,
+        profile: FileProfile,
+        ingest_key: str,
+        ingest_run_id: str,
+    ) -> ProcessingResult: ...
+```
+
+**Key observations:**
+- The processor does NOT receive `ParseStageResult` or `ClassificationStageResult` -- these must be reconstructed or passed differently. Looking at SPEC section 13.1 (router flow), the router assembles the final `ProcessingResult`. The processor may return a partial result or a tuple of its outputs.
+- **DECISION**: The processor should return a `ProcessingResult` fully assembled. The `parse_result` and `classification_result` fields will need to be passed in OR the processor builds a partial result and the router fills in the rest. Given the SPEC shows `process()` returning `ProcessingResult`, the processor must accept enough info to build the full result, OR the caller (router) augments it after.
+- **Recommended approach**: The processor's `process()` returns `ProcessingResult`. For `parse_result` and `classification_result`, either:
+  1. Accept them as additional parameters, OR
+  2. Return a simpler intermediate result that the router wraps
+
+Looking at the SPEC example signature: `process(self, file_path, profile, ingest_key, ingest_run_id) -> ProcessingResult`, it does NOT include parse/classification results. This means the processor either:
+- Has access to them via some other mechanism, OR
+- Only populates the fields it owns and the router fills in the rest
+
+**Best approach**: Accept `classification` and `parse_result` as additional parameters beyond the SPEC signature, since `ProcessingResult` requires them. Alternatively, make them part of a context object. The simplest deviation: add `classification_result` and `parse_result` params.
+
+---
+
+## 15. Test Patterns (from conftest.py and test_inspector.py)
+
+### Fixture Style
+- Use `@pytest.fixture()` with explicit parens
+- Return typed objects
+- Use helper functions like `_make_sheet_profile(**overrides)` and `_make_file_profile(sheets, **overrides)`
+
+### Helper Pattern
+```python
+def _make_sheet_profile(**overrides: object) -> SheetProfile:
+    defaults: dict = dict(
+        name="Sheet1",
+        row_count=100,
+        col_count=5,
+        # ... all fields with sensible defaults
+    )
+    defaults.update(overrides)
+    return SheetProfile(**defaults)
+```
+
+### Test Style
+- Tests grouped by functionality with section headers using `# ---------------------------------------------------------------------------`
+- Docstrings on test files and test classes
+- Import only what's needed from `ingestkit_excel.models`
+- No mock framework visible in conftest -- just plain fixtures
+
+---
+
+## 16. Files to Create
+
+### `src/ingestkit_excel/processors/__init__.py` (NEW)
+- Empty or with re-exports of `StructuredDBProcessor`
+
+### `src/ingestkit_excel/processors/structured_db.py` (NEW)
+- The main processor class
+- All 7 steps implemented
+- Helper functions for column cleaning, date detection, schema description generation, row serialization
+
+### `tests/test_structured_db.py` (NEW, if tests are part of this issue)
+- Tests for column cleaning, date parsing, schema description, row serialization, full process flow
+- Use mock backends
+
+---
+
+## 17. Process Flow Summary
+
+```
+process(file_path, profile, ingest_key, ingest_run_id)
+    |
+    +-- for each sheet in profile.sheets:
+    |       |
+    |       +-- Step 1: pd.read_excel(file_path, sheet_name=sheet.name)
+    |       +-- Step 2: clean_column_names(df) if config.clean_column_names
+    |       +-- Step 3: auto_detect_dates(df)
+    |       +-- Step 4: derive table_name, structured_db.create_table_from_dataframe(table_name, df)
+    |       +-- Step 5: generate schema_description(table_name, df)
+    |       +-- Step 6: embed schema, build ChunkPayload, upsert to vector store
+    |       +-- Step 7: if len(df) < row_serialization_limit:
+    |               +-- serialize rows, embed in batches, upsert to vector store
+    |
+    +-- Assemble ProcessingResult with WrittenArtifacts
+    +-- Return
+```
+
+---
+
+## 18. source_uri Convention
+
+From `idempotency.py` line 67-68:
+```python
+if source_uri is None:
+    source_uri = Path(file_path).resolve().as_posix()
+```
+
+The processor receives `file_path` as a parameter. For `ChunkMetadata.source_uri`, use the same pattern: resolve the path to an absolute POSIX path. The SPEC example shows `"file:///path/to/roster.xlsx"` format. The idempotency module uses just the POSIX path without the `file://` prefix. Need to decide on convention -- follow what the router passes (likely `file_path` resolved to absolute).
+
+Looking at the SPEC section 10.1 example:
+```python
+source_uri="file:///path/to/roster.xlsx"
+```
+
+The `source_uri` in ChunkMetadata should use the `file://` protocol prefix for local files. The processor should accept `source_uri` as a parameter OR derive it from `file_path` with the `file://` prefix.
+
+**Recommended**: Accept `source_uri` as an optional parameter to `process()`. If not provided, derive as `f"file://{Path(file_path).resolve().as_posix()}"`. The router will likely pass it from the ingest key computation.
+
+---
+
+## 19. Embedding Batching Strategy
+
+When embedding multiple texts (schema descriptions + optional row serializations):
+
+1. Collect all texts to embed
+2. Split into batches of `config.embedding_batch_size` (default: 64)
+3. Call `embedder.embed(batch, timeout=config.backend_timeout_seconds)` per batch
+4. Reassemble vectors in order
+5. Track total `texts_embedded` for `EmbedStageResult`
+6. Track total `embed_duration_seconds`
+
+---
+
+## 20. Error Handling Strategy
+
+The processor should:
+1. Catch backend exceptions and wrap them in `IngestError` with appropriate `ErrorCode`
+2. For non-fatal errors (e.g., one sheet fails but others succeed), continue processing and accumulate errors
+3. For fatal errors (e.g., all DB writes fail), stop and return result with errors
+4. Use `stage="process"` for processing errors and `stage="embed"` for embedding errors
+5. `E_PROCESS_SCHEMA_GEN` if schema description generation fails
+6. Backend errors (`E_BACKEND_*`) if backend calls fail after retries

--- a/.agents/outputs/patch-8-021026.md
+++ b/.agents/outputs/patch-8-021026.md
@@ -1,0 +1,99 @@
+# PATCH Artifact: Issue #8 -- Path A Structured DB Processor
+
+**Issue:** #8
+**Date:** 2026-02-11
+**Plan artifact:** `plan-8-021026.md`
+**Map artifact:** `map-8-021026.md`
+**Status:** IMPLEMENTED -- all tests passing
+
+---
+
+## Files Created
+
+### 1. `src/ingestkit_excel/processors/__init__.py` (NEW)
+
+Re-exports `StructuredDBProcessor` from the `structured_db` submodule.
+
+### 2. `src/ingestkit_excel/processors/structured_db.py` (NEW)
+
+Main processor implementation containing:
+
+- **Module-level helpers:**
+  - `clean_name(raw: str) -> str` -- Cleans column/sheet names for DB identifiers (lowercase, special chars to underscores, dedup consecutive underscores, strip leading/trailing).
+  - `deduplicate_names(names: list[str]) -> list[str]` -- Deduplicates cleaned names with `_1`, `_2` suffixes. Empty names become `column_N`.
+
+- **`StructuredDBProcessor` class:**
+  - `__init__(structured_db, vector_store, embedder, config)` -- Accepts all backend dependencies.
+  - `process(file_path, profile, ingest_key, ingest_run_id, parse_result, classification_result, classification) -> ProcessingResult` -- Full Path A processing pipeline.
+  - `_auto_detect_dates(df)` -- Two heuristics: Excel serial dates (35000-55000 range) and string dates (>50% parse threshold). Compatible with pandas 3.0 `StringDtype`.
+  - `_generate_schema_description(table_name, df)` -- Natural language schema for embedding.
+  - `_infer_type_label(series)` -- Maps pandas dtypes to human labels.
+  - `_describe_column(series, col_type, low_card_threshold)` -- Generates column value descriptions.
+  - `_serialize_rows(...)` -- Converts rows to NL sentences for vector search.
+  - `_classify_backend_error(exc)` -- Maps exceptions to ErrorCode values.
+
+### 3. `tests/test_structured_db.py` (NEW)
+
+59 tests organized in 9 test classes:
+
+| Class | Tests | Coverage |
+|---|---|---|
+| `TestCleanName` | 7 | Column name cleaning edge cases |
+| `TestDeduplicateNames` | 4 | Name deduplication logic |
+| `TestAutoDetectDates` | 6 | Date detection heuristics |
+| `TestSchemaDescription` | 8 | Schema description generation |
+| `TestSerializeRows` | 5 | Row serialization format and metadata |
+| `TestProcessFlow` | 12 | Full process() happy path and field verification |
+| `TestRowSerializationIntegration` | 4 | Row serialization triggers and batching |
+| `TestMultiSheetProcessing` | 3 | Multi-sheet, global chunk index, name dedup |
+| `TestSheetSkipping` | 3 | Hidden, oversized, all-skipped scenarios |
+| `TestErrorHandling` | 5 | DB/embed failures, error details, continuation |
+| `TestConfigInteractions` | 2 | Config-driven behavior (clean names, custom collection) |
+
+Mock backends: `MockStructuredDB`, `MockVectorStore`, `MockEmbedder` -- all defined in-file with recording capabilities and configurable failure modes.
+
+---
+
+## Files Modified
+
+### 4. `src/ingestkit_excel/__init__.py` (MODIFIED)
+
+- Added `from ingestkit_excel.processors import StructuredDBProcessor` import.
+- Added `"StructuredDBProcessor"` to `__all__` list under `# Processors` section.
+
+---
+
+## Key Implementation Decisions
+
+### pandas 3.0 Compatibility
+
+The project uses pandas 3.0.0, which defaults to `StringDtype` instead of `object` for string columns. The date detection heuristic was updated to check both:
+
+```python
+if series.dtype == object or pd.api.types.is_string_dtype(series):
+```
+
+This ensures string date detection works with both pandas 2.x (`object` dtype) and pandas 3.x (`StringDtype`).
+
+### ENUM_VALUE Pattern
+
+Correctly applied throughout:
+- `ChunkMetadata.ingestion_method` = `IngestionMethod.SQL_AGENT.value` = `"sql_agent"` (string)
+- `ProcessingResult.ingestion_method` = `IngestionMethod.SQL_AGENT` (enum member)
+- `ChunkMetadata.parser_used` = `sheet.parser_used.value` = `"openpyxl"` (string)
+- Warning/error strings use `ErrorCode.*.value`
+
+### Date Detection with `format="mixed"`
+
+Uses `format="mixed"` instead of the deprecated `infer_datetime_format=True`, compatible with pandas >= 2.0.
+
+---
+
+## Test Results
+
+```
+335 passed in 0.46s
+```
+
+- 276 existing tests: all pass (no regressions)
+- 59 new tests: all pass

--- a/.agents/outputs/plan-8-021026.md
+++ b/.agents/outputs/plan-8-021026.md
@@ -1,0 +1,1106 @@
+# PLAN: Issue #8 -- Path A Structured DB Processor
+
+**Issue:** #8
+**Date:** 2026-02-11
+**MAP artifact:** `map-8-021026.md`
+**Status:** PLAN ready for IMPLEMENT agent
+
+---
+
+## 1. Directory Structure
+
+```
+src/ingestkit_excel/
+    processors/
+        __init__.py           # NEW -- re-exports StructuredDBProcessor
+        structured_db.py      # NEW -- main processor class + helpers
+tests/
+    test_structured_db.py     # NEW -- full test suite
+```
+
+No existing files are modified except `src/ingestkit_excel/__init__.py` (add processor to public API).
+
+---
+
+## 2. File: `src/ingestkit_excel/processors/__init__.py`
+
+```python
+"""Processing-path implementations for ingestkit-excel."""
+
+from ingestkit_excel.processors.structured_db import StructuredDBProcessor
+
+__all__ = ["StructuredDBProcessor"]
+```
+
+---
+
+## 3. File: `src/ingestkit_excel/processors/structured_db.py`
+
+### 3.1 Imports (exact)
+
+```python
+"""Path A processor: structured DB ingestion with optional row serialization."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import time
+import uuid
+from pathlib import Path
+
+import pandas as pd
+
+from ingestkit_excel.config import ExcelProcessorConfig
+from ingestkit_excel.errors import ErrorCode, IngestError
+from ingestkit_excel.models import (
+    ChunkMetadata,
+    ChunkPayload,
+    ClassificationResult,
+    ClassificationStageResult,
+    EmbedStageResult,
+    FileProfile,
+    IngestionMethod,
+    ParseStageResult,
+    ProcessingResult,
+    SheetProfile,
+    WrittenArtifacts,
+)
+from ingestkit_excel.protocols import (
+    EmbeddingBackend,
+    StructuredDBBackend,
+    VectorStoreBackend,
+)
+
+logger = logging.getLogger(__name__)
+```
+
+### 3.2 Module-level helpers (not methods -- used by tests directly)
+
+#### `clean_name(raw: str) -> str`
+
+```python
+def clean_name(raw: str) -> str:
+    """Clean a raw name (column or sheet) for use as a DB identifier.
+
+    Rules:
+    1. Lowercase
+    2. Replace non-alphanumeric/underscore with underscore
+    3. Collapse consecutive underscores
+    4. Strip leading/trailing underscores
+    """
+    name = raw.lower()
+    name = re.sub(r"[^a-z0-9_]", "_", name)
+    name = re.sub(r"_+", "_", name)
+    name = name.strip("_")
+    return name
+```
+
+#### `deduplicate_names(names: list[str]) -> list[str]`
+
+```python
+def deduplicate_names(names: list[str]) -> list[str]:
+    """Deduplicate a list of cleaned names by appending _1, _2, etc.
+
+    Empty names after cleaning become ``column_N`` where N is the 0-based index.
+    """
+    seen: dict[str, int] = {}
+    result: list[str] = []
+    for i, name in enumerate(names):
+        if not name:
+            name = f"column_{i}"
+        if name in seen:
+            seen[name] += 1
+            result.append(f"{name}_{seen[name]}")
+        else:
+            seen[name] = 0
+            result.append(name)
+    return result
+```
+
+### 3.3 Class: `StructuredDBProcessor`
+
+#### Constructor
+
+```python
+class StructuredDBProcessor:
+    """Path A processor: writes each sheet to a structured DB table,
+    generates NL schema descriptions, embeds them, and optionally
+    serializes rows for direct vector search.
+    """
+
+    def __init__(
+        self,
+        structured_db: StructuredDBBackend,
+        vector_store: VectorStoreBackend,
+        embedder: EmbeddingBackend,
+        config: ExcelProcessorConfig,
+    ) -> None:
+        self._db = structured_db
+        self._vector_store = vector_store
+        self._embedder = embedder
+        self._config = config
+```
+
+#### `process()` -- Main entry point
+
+**Signature:**
+```python
+def process(
+    self,
+    file_path: str,
+    profile: FileProfile,
+    ingest_key: str,
+    ingest_run_id: str,
+    parse_result: ParseStageResult,
+    classification_result: ClassificationStageResult,
+    classification: ClassificationResult,
+) -> ProcessingResult:
+```
+
+**IMPORTANT on `ingest_key` parameter**: The MAP section 14 shows the `process()` signature accepting `ingest_key: str` (the deterministic SHA-256 hex string from `IngestKey.key` property), NOT an `IngestKey` object. This matches `ProcessingResult.ingest_key: str`.
+
+**IMPORTANT on additional parameters**: `ProcessingResult` **requires** `parse_result`, `classification_result`, and `classification` (no defaults). The processor must receive these from the caller (router) and pass them through. The MAP section 14 recommends accepting them as additional parameters.
+
+**Pseudocode:**
+
+```python
+def process(self, file_path, profile, ingest_key, ingest_run_id,
+            parse_result, classification_result, classification):
+    start_time = time.monotonic()
+
+    config = self._config
+    collection = config.default_collection
+    source_uri = f"file://{Path(file_path).resolve().as_posix()}"
+    db_uri = self._db.get_connection_uri()
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    error_details: list[IngestError] = []
+
+    written = WrittenArtifacts(vector_collection=collection)
+    tables: list[str] = []
+    total_chunks = 0
+    total_texts_embedded = 0
+    embed_duration = 0.0
+
+    # Ensure vector collection exists
+    vector_size = self._embedder.dimension()
+    self._vector_store.ensure_collection(collection, vector_size)
+
+    chunk_index_counter = 0  # global chunk index across all sheets
+
+    for sheet in profile.sheets:
+        # --- Skip logic ---
+        if sheet.is_hidden:
+            warnings.append(ErrorCode.W_SHEET_SKIPPED_HIDDEN.value)
+            logger.info("Skipping hidden sheet: %s", sheet.name)
+            continue
+        if sheet.row_count == 0 and sheet.col_count == 0:
+            # chart-only heuristic
+            warnings.append(ErrorCode.W_SHEET_SKIPPED_CHART.value)
+            logger.info("Skipping chart-only sheet: %s", sheet.name)
+            continue
+        if sheet.row_count > config.max_rows_in_memory:
+            warnings.append(ErrorCode.W_ROWS_TRUNCATED.value)
+            logger.warning(
+                "Sheet %s has %d rows, exceeds max_rows_in_memory (%d), skipping",
+                sheet.name, sheet.row_count, config.max_rows_in_memory,
+            )
+            continue
+
+        try:
+            # --- Step 1: Load DataFrame ---
+            header_arg = sheet.header_row_index if sheet.header_row_detected else None
+            df = pd.read_excel(
+                file_path, sheet_name=sheet.name, header=header_arg,
+            )
+
+            # --- Step 2: Clean column names ---
+            if config.clean_column_names:
+                cleaned = [clean_name(str(c)) for c in df.columns]
+                cleaned = deduplicate_names(cleaned)
+                df.columns = cleaned
+
+            # --- Step 3: Auto-detect dates ---
+            df = self._auto_detect_dates(df)
+
+            # --- Step 4: Write to DB ---
+            table_name = clean_name(sheet.name)
+            if not table_name:
+                table_name = f"sheet_{profile.sheets.index(sheet)}"
+            # Deduplicate table names across sheets
+            if table_name in tables:
+                suffix = 1
+                while f"{table_name}_{suffix}" in tables:
+                    suffix += 1
+                table_name = f"{table_name}_{suffix}"
+
+            self._db.create_table_from_dataframe(table_name, df)
+            written.db_table_names.append(table_name)
+            tables.append(table_name)
+
+            # --- Step 5: Generate schema description ---
+            schema_text = self._generate_schema_description(table_name, df)
+
+            # --- Step 6: Embed schema + upsert ---
+            embed_start = time.monotonic()
+            vectors = self._embedder.embed(
+                [schema_text], timeout=config.backend_timeout_seconds,
+            )
+            embed_duration += time.monotonic() - embed_start
+            total_texts_embedded += 1
+
+            chunk_hash = hashlib.sha256(schema_text.encode()).hexdigest()
+            chunk_id = str(uuid.uuid5(
+                uuid.NAMESPACE_URL, f"{ingest_key}:{chunk_hash}",
+            ))
+            columns_list = list(df.columns)
+
+            metadata = ChunkMetadata(
+                source_uri=source_uri,
+                source_format="xlsx",
+                sheet_name=sheet.name,
+                region_id=None,
+                ingestion_method=IngestionMethod.SQL_AGENT.value,  # "sql_agent"
+                parser_used=sheet.parser_used.value,               # "openpyxl"
+                parser_version=config.parser_version,
+                chunk_index=chunk_index_counter,
+                chunk_hash=chunk_hash,
+                ingest_key=ingest_key,
+                ingest_run_id=ingest_run_id,
+                tenant_id=config.tenant_id,
+                table_name=table_name,
+                db_uri=db_uri,
+                row_count=len(df),
+                columns=columns_list,
+            )
+            chunk = ChunkPayload(
+                id=chunk_id,
+                text=schema_text,
+                vector=vectors[0],
+                metadata=metadata,
+            )
+
+            self._vector_store.upsert_chunks(collection, [chunk])
+            written.vector_point_ids.append(chunk_id)
+            chunk_index_counter += 1
+            total_chunks += 1
+
+            # --- Step 7: Optional row serialization ---
+            if len(df) < config.row_serialization_limit:
+                row_chunks = self._serialize_rows(
+                    table_name=table_name,
+                    df=df,
+                    start_chunk_index=chunk_index_counter,
+                    sheet=sheet,
+                    source_uri=source_uri,
+                    db_uri=db_uri,
+                    ingest_key=ingest_key,
+                    ingest_run_id=ingest_run_id,
+                )
+                # Embed in batches
+                for batch_start in range(0, len(row_chunks), config.embedding_batch_size):
+                    batch = row_chunks[batch_start:batch_start + config.embedding_batch_size]
+                    texts = [c.text for c in batch]
+                    embed_start = time.monotonic()
+                    vectors = self._embedder.embed(
+                        texts, timeout=config.backend_timeout_seconds,
+                    )
+                    embed_duration += time.monotonic() - embed_start
+                    total_texts_embedded += len(texts)
+                    for c, vec in zip(batch, vectors):
+                        c.vector = vec
+
+                    self._vector_store.upsert_chunks(collection, list(batch))
+                    for c in batch:
+                        written.vector_point_ids.append(c.id)
+                    total_chunks += len(batch)
+
+                chunk_index_counter += len(row_chunks)
+
+        except Exception as exc:
+            # Per-sheet error handling: log, record, continue to next sheet
+            error_code = self._classify_backend_error(exc)
+            errors.append(error_code.value)
+            error_details.append(IngestError(
+                code=error_code,
+                message=str(exc),
+                sheet_name=sheet.name,
+                stage="process",
+                recoverable=False,
+            ))
+            logger.exception("Error processing sheet %s: %s", sheet.name, exc)
+            continue
+
+    # --- Assemble EmbedStageResult ---
+    embed_result = None
+    if total_texts_embedded > 0:
+        embed_result = EmbedStageResult(
+            texts_embedded=total_texts_embedded,
+            embedding_dimension=self._embedder.dimension(),
+            embed_duration_seconds=embed_duration,
+        )
+
+    elapsed = time.monotonic() - start_time
+
+    return ProcessingResult(
+        file_path=file_path,
+        ingest_key=ingest_key,
+        ingest_run_id=ingest_run_id,
+        tenant_id=config.tenant_id,
+        parse_result=parse_result,
+        classification_result=classification_result,
+        embed_result=embed_result,
+        classification=classification,
+        ingestion_method=IngestionMethod.SQL_AGENT,  # enum member, NOT string
+        chunks_created=total_chunks,
+        tables_created=len(tables),
+        tables=tables,
+        written=written,
+        errors=errors,
+        warnings=warnings,
+        error_details=error_details,
+        processing_time_seconds=elapsed,
+    )
+```
+
+### 3.4 Private methods
+
+#### `_auto_detect_dates(self, df: pd.DataFrame) -> pd.DataFrame`
+
+```python
+def _auto_detect_dates(self, df: pd.DataFrame) -> pd.DataFrame:
+    """Auto-detect and convert date columns in-place.
+
+    Two heuristics:
+    1. Excel serial dates: numeric columns with values in 40000..50000 range
+    2. String dates: object columns where >50% of non-null values parse as dates
+    """
+    SERIAL_MIN = 35_000   # ~1995
+    SERIAL_MAX = 55_000   # ~2050
+    DATE_PARSE_THRESHOLD = 0.5
+
+    for col in df.columns:
+        series = df[col]
+        non_null = series.dropna()
+        if len(non_null) == 0:
+            continue
+
+        # Heuristic 1: Excel serial dates
+        if pd.api.types.is_numeric_dtype(series):
+            if (non_null >= SERIAL_MIN).all() and (non_null <= SERIAL_MAX).all():
+                try:
+                    df[col] = pd.to_datetime(
+                        series, origin="1899-12-30", unit="D", errors="coerce",
+                    )
+                    logger.debug("Converted column '%s' from Excel serial date", col)
+                except Exception:
+                    pass  # leave as-is if conversion fails
+            continue
+
+        # Heuristic 2: String dates (object dtype only)
+        if series.dtype == object:
+            try:
+                parsed = pd.to_datetime(non_null, format="mixed", errors="coerce")
+                success_ratio = parsed.notna().sum() / len(non_null)
+                if success_ratio >= DATE_PARSE_THRESHOLD:
+                    df[col] = pd.to_datetime(
+                        series, format="mixed", errors="coerce",
+                    )
+                    logger.debug(
+                        "Converted column '%s' from string dates (%.0f%% parsed)",
+                        col, success_ratio * 100,
+                    )
+            except Exception:
+                pass  # leave as-is
+
+    return df
+```
+
+**NOTE on `infer_datetime_format`**: The MAP references `infer_datetime_format=True` but this parameter is deprecated in pandas >= 2.0. Use `format="mixed"` instead, which is the modern equivalent. The IMPLEMENT agent should verify pandas version in the project's dependencies and use `format="mixed"` if pandas >= 2.0 (which it will be, given the project uses Python 3.12).
+
+#### `_generate_schema_description(self, table_name: str, df: pd.DataFrame) -> str`
+
+```python
+def _generate_schema_description(self, table_name: str, df: pd.DataFrame) -> str:
+    """Generate a natural language schema description for embedding.
+
+    Format:
+        Table "{table_name}" contains {N} rows with columns:
+        - col_name (type): description
+        ...
+    """
+    LOW_CARDINALITY_THRESHOLD = 20
+    lines = [f'Table "{table_name}" contains {len(df)} rows with columns:']
+
+    for col in df.columns:
+        series = df[col].dropna()
+        col_type = self._infer_type_label(df[col])
+        desc = self._describe_column(series, col_type, LOW_CARDINALITY_THRESHOLD)
+        lines.append(f"- {col} ({col_type}): {desc}")
+
+    return "\n".join(lines)
+```
+
+#### `_infer_type_label(self, series: pd.Series) -> str`
+
+```python
+@staticmethod
+def _infer_type_label(series: pd.Series) -> str:
+    """Map a pandas dtype to a human-readable type label."""
+    dtype = series.dtype
+    if pd.api.types.is_integer_dtype(dtype):
+        return "integer"
+    if pd.api.types.is_float_dtype(dtype):
+        return "float"
+    if pd.api.types.is_bool_dtype(dtype):
+        return "boolean"
+    if pd.api.types.is_datetime64_any_dtype(dtype):
+        return "date"
+    return "text"
+```
+
+#### `_describe_column(self, series: pd.Series, col_type: str, low_card_threshold: int) -> str`
+
+```python
+@staticmethod
+def _describe_column(
+    series: pd.Series, col_type: str, low_card_threshold: int,
+) -> str:
+    """Generate a human-readable description of a column's values."""
+    if len(series) == 0:
+        return "no data"
+
+    if col_type in ("integer", "float"):
+        return f"range {series.min()} to {series.max()}"
+
+    if col_type == "date":
+        return f"ranges from {series.min()} to {series.max()}"
+
+    if col_type == "boolean":
+        return "true/false"
+
+    # text
+    n_unique = series.nunique()
+    if n_unique < low_card_threshold:
+        unique_vals = ", ".join(str(v) for v in series.unique()[:low_card_threshold])
+        return f"one of {unique_vals}"
+    return f"{n_unique} unique values"
+```
+
+#### `_serialize_rows(self, ...) -> list[ChunkPayload]`
+
+```python
+def _serialize_rows(
+    self,
+    table_name: str,
+    df: pd.DataFrame,
+    start_chunk_index: int,
+    sheet: SheetProfile,
+    source_uri: str,
+    db_uri: str,
+    ingest_key: str,
+    ingest_run_id: str,
+) -> list[ChunkPayload]:
+    """Serialize each row into a natural language sentence.
+
+    Returns ChunkPayload objects with vectors set to empty lists.
+    Vectors are populated later during batch embedding.
+
+    Format: "In table '{table_name}', row {N}: {col} is {val}, ..."
+    """
+    config = self._config
+    columns_list = list(df.columns)
+    chunks: list[ChunkPayload] = []
+
+    for row_idx, row in df.iterrows():
+        # Build row text
+        parts = []
+        for col in df.columns:
+            val = row[col]
+            if pd.isna(val):
+                parts.append(f"{col} is N/A")
+            else:
+                parts.append(f"{col} is {val}")
+        row_number = row_idx + 1 if isinstance(row_idx, int) else row_idx
+        text = f"In table '{table_name}', row {row_number}: {', '.join(parts)}."
+
+        chunk_hash = hashlib.sha256(text.encode()).hexdigest()
+        chunk_id = str(uuid.uuid5(
+            uuid.NAMESPACE_URL, f"{ingest_key}:{chunk_hash}",
+        ))
+        chunk_index = start_chunk_index + len(chunks)
+
+        metadata = ChunkMetadata(
+            source_uri=source_uri,
+            source_format="xlsx",
+            sheet_name=sheet.name,
+            region_id=None,
+            ingestion_method=IngestionMethod.SQL_AGENT.value,  # "sql_agent"
+            parser_used=sheet.parser_used.value,
+            parser_version=config.parser_version,
+            chunk_index=chunk_index,
+            chunk_hash=chunk_hash,
+            ingest_key=ingest_key,
+            ingest_run_id=ingest_run_id,
+            tenant_id=config.tenant_id,
+            table_name=table_name,
+            db_uri=db_uri,
+            row_count=len(df),
+            columns=columns_list,
+        )
+        chunks.append(ChunkPayload(
+            id=chunk_id,
+            text=text,
+            vector=[],  # placeholder; populated during batch embedding
+            metadata=metadata,
+        ))
+
+    return chunks
+```
+
+#### `_classify_backend_error(self, exc: Exception) -> ErrorCode`
+
+```python
+@staticmethod
+def _classify_backend_error(exc: Exception) -> ErrorCode:
+    """Map an exception to the most appropriate ErrorCode.
+
+    Inspects exception type and message to differentiate timeout vs
+    connection errors for each backend type.
+    """
+    msg = str(exc).lower()
+    if "timeout" in msg or "timed out" in msg:
+        if "embed" in msg:
+            return ErrorCode.E_BACKEND_EMBED_TIMEOUT
+        if "vector" in msg or "qdrant" in msg or "collection" in msg:
+            return ErrorCode.E_BACKEND_VECTOR_TIMEOUT
+        return ErrorCode.E_BACKEND_DB_TIMEOUT
+    if "connect" in msg or "connection" in msg:
+        if "embed" in msg:
+            return ErrorCode.E_BACKEND_EMBED_CONNECT
+        if "vector" in msg or "qdrant" in msg or "collection" in msg:
+            return ErrorCode.E_BACKEND_VECTOR_CONNECT
+        return ErrorCode.E_BACKEND_DB_CONNECT
+    # Default to schema gen error for unknown exceptions during processing
+    return ErrorCode.E_PROCESS_SCHEMA_GEN
+```
+
+---
+
+## 4. ChunkMetadata Field Mapping (complete reference)
+
+| ChunkMetadata field | Schema chunk source | Row chunk source |
+|---|---|---|
+| `source_uri` | `f"file://{Path(file_path).resolve().as_posix()}"` | same |
+| `source_format` | `"xlsx"` (default) | same |
+| `sheet_name` | `sheet.name` (SheetProfile) | same |
+| `region_id` | `None` | `None` |
+| `ingestion_method` | `IngestionMethod.SQL_AGENT.value` = `"sql_agent"` | same |
+| `parser_used` | `sheet.parser_used.value` (e.g. `"openpyxl"`) | same |
+| `parser_version` | `config.parser_version` (e.g. `"ingestkit_excel:1.0.0"`) | same |
+| `chunk_index` | `0` for first schema chunk, incrementing globally | continues after schema chunk |
+| `chunk_hash` | `hashlib.sha256(schema_text.encode()).hexdigest()` | `hashlib.sha256(row_text.encode()).hexdigest()` |
+| `ingest_key` | passed parameter (SHA-256 hex string from `IngestKey.key`) | same |
+| `ingest_run_id` | passed parameter (UUID4 string) | same |
+| `tenant_id` | `config.tenant_id` | same |
+| `table_name` | cleaned table name from `clean_name(sheet.name)` | same |
+| `db_uri` | `self._db.get_connection_uri()` | same |
+| `row_count` | `len(df)` | same |
+| `columns` | `list(df.columns)` after cleaning | same |
+| `section_title` | `None` (Path B only) | `None` |
+| `original_structure` | `None` (Path B only) | `None` |
+
+### ChunkPayload.id generation
+
+```python
+chunk_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{ingest_key}:{chunk_hash}"))
+```
+
+Deterministic: same content + same ingest_key = same ID (idempotent upserts).
+
+---
+
+## 5. Enum Values Used (complete reference)
+
+| Location | Python expression | Resulting string |
+|---|---|---|
+| `ChunkMetadata.ingestion_method` | `IngestionMethod.SQL_AGENT.value` | `"sql_agent"` |
+| `ChunkMetadata.parser_used` | `sheet.parser_used.value` | `"openpyxl"` or `"pandas_fallback"` |
+| `ProcessingResult.ingestion_method` | `IngestionMethod.SQL_AGENT` | enum member (not string) |
+| Warnings list entries | `ErrorCode.W_SHEET_SKIPPED_HIDDEN.value` | `"W_SHEET_SKIPPED_HIDDEN"` |
+| Warnings list entries | `ErrorCode.W_SHEET_SKIPPED_CHART.value` | `"W_SHEET_SKIPPED_CHART"` |
+| Warnings list entries | `ErrorCode.W_ROWS_TRUNCATED.value` | `"W_ROWS_TRUNCATED"` |
+| Errors list entries | `ErrorCode.E_BACKEND_DB_TIMEOUT.value` | `"E_BACKEND_DB_TIMEOUT"` |
+| Errors list entries | `ErrorCode.E_BACKEND_DB_CONNECT.value` | `"E_BACKEND_DB_CONNECT"` |
+| Errors list entries | `ErrorCode.E_BACKEND_VECTOR_TIMEOUT.value` | `"E_BACKEND_VECTOR_TIMEOUT"` |
+| Errors list entries | `ErrorCode.E_BACKEND_EMBED_TIMEOUT.value` | `"E_BACKEND_EMBED_TIMEOUT"` |
+| Errors list entries | `ErrorCode.E_PROCESS_SCHEMA_GEN.value` | `"E_PROCESS_SCHEMA_GEN"` |
+| `IngestError.stage` | literal string | `"process"` or `"embed"` |
+
+---
+
+## 6. File: `src/ingestkit_excel/__init__.py` Update
+
+Add after the `LLMClassifier` import and before `protocols`:
+
+```python
+from ingestkit_excel.processors import StructuredDBProcessor
+```
+
+Add to `__all__` list after `"LLMClassifier"`:
+
+```python
+    # Processors
+    "StructuredDBProcessor",
+```
+
+---
+
+## 7. File: `tests/test_structured_db.py`
+
+### 7.1 Imports
+
+```python
+"""Tests for the StructuredDBProcessor (Path A).
+
+Covers column cleaning, date detection, schema description generation,
+row serialization, full process flow, multi-sheet processing, error
+handling, and WrittenArtifacts tracking.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from ingestkit_excel.config import ExcelProcessorConfig
+from ingestkit_excel.errors import ErrorCode, IngestError
+from ingestkit_excel.models import (
+    ChunkMetadata,
+    ChunkPayload,
+    ClassificationResult,
+    ClassificationStageResult,
+    ClassificationTier,
+    EmbedStageResult,
+    FileProfile,
+    FileType,
+    IngestionMethod,
+    ParseStageResult,
+    ParserUsed,
+    ProcessingResult,
+    SheetProfile,
+    WrittenArtifacts,
+)
+from ingestkit_excel.processors.structured_db import (
+    StructuredDBProcessor,
+    clean_name,
+    deduplicate_names,
+)
+```
+
+### 7.2 Test Helper Factories
+
+```python
+def _make_sheet_profile(**overrides: object) -> SheetProfile:
+    """Build a SheetProfile with sensible tabular defaults."""
+    defaults: dict = dict(
+        name="Sheet1",
+        row_count=100,
+        col_count=5,
+        merged_cell_count=0,
+        merged_cell_ratio=0.0,
+        header_row_detected=True,
+        header_row_index=0,
+        header_values=["A", "B", "C", "D", "E"],
+        column_type_consistency=0.9,
+        numeric_ratio=0.4,
+        text_ratio=0.5,
+        empty_ratio=0.1,
+        sample_rows=[["1", "a", "x", "2.0", "y"]],
+        has_formulas=False,
+        is_hidden=False,
+        parser_used=ParserUsed.OPENPYXL,
+    )
+    defaults.update(overrides)
+    return SheetProfile(**defaults)
+
+
+def _make_file_profile(
+    sheets: list[SheetProfile], **overrides: object,
+) -> FileProfile:
+    """Build a FileProfile from a list of SheetProfiles."""
+    defaults: dict = dict(
+        file_path="/tmp/test.xlsx",
+        file_size_bytes=1024,
+        sheet_count=len(sheets),
+        sheet_names=[s.name for s in sheets],
+        sheets=sheets,
+        has_password_protected_sheets=False,
+        has_chart_only_sheets=False,
+        total_merged_cells=sum(s.merged_cell_count for s in sheets),
+        total_rows=sum(s.row_count for s in sheets),
+        content_hash="a" * 64,
+    )
+    defaults.update(overrides)
+    return FileProfile(**defaults)
+
+
+def _make_parse_result(**overrides: object) -> ParseStageResult:
+    defaults: dict = dict(
+        parser_used=ParserUsed.OPENPYXL,
+        fallback_reason_code=None,
+        sheets_parsed=1,
+        sheets_skipped=0,
+        skipped_reasons={},
+        parse_duration_seconds=0.1,
+    )
+    defaults.update(overrides)
+    return ParseStageResult(**defaults)
+
+
+def _make_classification_stage_result(**overrides: object) -> ClassificationStageResult:
+    defaults: dict = dict(
+        tier_used=ClassificationTier.RULE_BASED,
+        file_type=FileType.TABULAR_DATA,
+        confidence=0.95,
+        signals=None,
+        reasoning="High column consistency, low merged cells",
+        per_sheet_types=None,
+        classification_duration_seconds=0.05,
+    )
+    defaults.update(overrides)
+    return ClassificationStageResult(**defaults)
+
+
+def _make_classification_result(**overrides: object) -> ClassificationResult:
+    defaults: dict = dict(
+        file_type=FileType.TABULAR_DATA,
+        confidence=0.95,
+        tier_used=ClassificationTier.RULE_BASED,
+        reasoning="High column consistency, low merged cells",
+        per_sheet_types=None,
+        signals=None,
+    )
+    defaults.update(overrides)
+    return ClassificationResult(**defaults)
+```
+
+### 7.3 Mock Backend Design
+
+```python
+class MockStructuredDB:
+    """Mock StructuredDBBackend for testing."""
+
+    def __init__(self, connection_uri: str = "sqlite:///test.db"):
+        self._uri = connection_uri
+        self.tables_created: list[tuple[str, pd.DataFrame]] = []
+        self.fail_on: str | None = None  # table name to fail on
+
+    def create_table_from_dataframe(self, table_name: str, df: pd.DataFrame) -> None:
+        if self.fail_on and table_name == self.fail_on:
+            raise RuntimeError(f"DB connection error for table {table_name}")
+        self.tables_created.append((table_name, df.copy()))
+
+    def drop_table(self, table_name: str) -> None:
+        pass
+
+    def table_exists(self, table_name: str) -> bool:
+        return any(t[0] == table_name for t in self.tables_created)
+
+    def get_table_schema(self, table_name: str) -> dict:
+        return {}
+
+    def get_connection_uri(self) -> str:
+        return self._uri
+
+
+class MockVectorStore:
+    """Mock VectorStoreBackend for testing."""
+
+    def __init__(self):
+        self.collections_ensured: list[tuple[str, int]] = []
+        self.upserted: list[tuple[str, list[ChunkPayload]]] = []
+        self.fail_on_upsert: bool = False
+
+    def upsert_chunks(self, collection: str, chunks: list[ChunkPayload]) -> int:
+        if self.fail_on_upsert:
+            raise RuntimeError("Vector store connection error")
+        self.upserted.append((collection, chunks))
+        return len(chunks)
+
+    def ensure_collection(self, collection: str, vector_size: int) -> None:
+        self.collections_ensured.append((collection, vector_size))
+
+    def create_payload_index(self, collection: str, field: str, field_type: str) -> None:
+        pass
+
+    def delete_by_ids(self, collection: str, ids: list[str]) -> int:
+        return len(ids)
+
+
+class MockEmbedder:
+    """Mock EmbeddingBackend for testing."""
+
+    def __init__(self, dim: int = 768):
+        self._dim = dim
+        self.embed_calls: list[list[str]] = []
+        self.fail_on_embed: bool = False
+
+    def embed(self, texts: list[str], timeout: float | None = None) -> list[list[float]]:
+        if self.fail_on_embed:
+            raise RuntimeError("Embedding timeout error")
+        self.embed_calls.append(texts)
+        return [[0.1] * self._dim for _ in texts]
+
+    def dimension(self) -> int:
+        return self._dim
+```
+
+### 7.4 Fixtures
+
+```python
+@pytest.fixture()
+def mock_db() -> MockStructuredDB:
+    return MockStructuredDB()
+
+
+@pytest.fixture()
+def mock_vector_store() -> MockVectorStore:
+    return MockVectorStore()
+
+
+@pytest.fixture()
+def mock_embedder() -> MockEmbedder:
+    return MockEmbedder()
+
+
+@pytest.fixture()
+def config() -> ExcelProcessorConfig:
+    return ExcelProcessorConfig()
+
+
+@pytest.fixture()
+def processor(
+    mock_db: MockStructuredDB,
+    mock_vector_store: MockVectorStore,
+    mock_embedder: MockEmbedder,
+    config: ExcelProcessorConfig,
+) -> StructuredDBProcessor:
+    return StructuredDBProcessor(mock_db, mock_vector_store, mock_embedder, config)
+```
+
+### 7.5 Complete Test Case List
+
+#### Section: Column Name Cleaning (`clean_name` and `deduplicate_names`)
+
+| # | Test name | What it verifies |
+|---|---|---|
+| 1 | `test_clean_name_lowercase` | `"Hello World"` -> `"hello_world"` |
+| 2 | `test_clean_name_special_chars` | `"Col #1 (USD)"` -> `"col_1_usd"` |
+| 3 | `test_clean_name_consecutive_underscores` | `"a___b"` -> `"a_b"` |
+| 4 | `test_clean_name_leading_trailing_underscores` | `"__name__"` -> `"name"` |
+| 5 | `test_clean_name_empty_string` | `""` -> `""` (handled by deduplicate_names) |
+| 6 | `test_clean_name_unicode` | `"Gebuhrenstatus"` (with umlaut) -> ASCII underscore replacement |
+| 7 | `test_clean_name_numeric_only` | `"123"` -> `"123"` |
+| 8 | `test_deduplicate_names_no_dupes` | `["a", "b", "c"]` -> `["a", "b", "c"]` |
+| 9 | `test_deduplicate_names_with_dupes` | `["a", "a", "a"]` -> `["a", "a_1", "a_2"]` |
+| 10 | `test_deduplicate_names_empty_becomes_column_n` | `["", "", "a"]` -> `["column_0", "column_1", "a"]` |
+| 11 | `test_deduplicate_names_mixed` | `["id", "", "id", "name"]` -> `["id", "column_1", "id_1", "name"]` |
+
+#### Section: Date Detection (`_auto_detect_dates`)
+
+| # | Test name | What it verifies |
+|---|---|---|
+| 12 | `test_auto_detect_excel_serial_dates` | Numeric column with values ~44000 converted to datetime |
+| 13 | `test_auto_detect_string_dates` | Object column with `"2023-01-15"` strings converted |
+| 14 | `test_auto_detect_skips_integers_outside_range` | Column with values 1-100 NOT converted (not in serial range) |
+| 15 | `test_auto_detect_mixed_dates_below_threshold` | Object column where <50% parse as dates left unconverted |
+| 16 | `test_auto_detect_empty_column_ignored` | All-NaN column not modified |
+| 17 | `test_auto_detect_preserves_non_date_columns` | Integer and text columns preserved |
+
+#### Section: Schema Description Generation
+
+| # | Test name | What it verifies |
+|---|---|---|
+| 18 | `test_schema_description_contains_table_name` | Output starts with `Table "table_name"` |
+| 19 | `test_schema_description_integer_column_range` | Integer col shows `"range X to Y"` |
+| 20 | `test_schema_description_float_column_range` | Float col shows `"range X to Y"` |
+| 21 | `test_schema_description_text_low_cardinality` | Text col with <20 unique shows `"one of ..."` |
+| 22 | `test_schema_description_text_high_cardinality` | Text col with >=20 unique shows `"N unique values"` |
+| 23 | `test_schema_description_date_column_range` | Date col shows `"ranges from X to Y"` |
+| 24 | `test_schema_description_boolean_column` | Bool col shows `"true/false"` |
+| 25 | `test_schema_description_row_count` | Output contains `"contains N rows"` |
+
+#### Section: Row Serialization
+
+| # | Test name | What it verifies |
+|---|---|---|
+| 26 | `test_serialize_rows_format` | Each row text matches `"In table '...', row N: col is val, ..."` |
+| 27 | `test_serialize_rows_handles_nan` | NaN values rendered as `"N/A"` |
+| 28 | `test_serialize_rows_chunk_metadata_correct` | Each chunk has correct table_name, chunk_index, sheet_name |
+| 29 | `test_serialize_rows_chunk_ids_deterministic` | Same content + ingest_key -> same chunk_id |
+| 30 | `test_serialize_rows_chunk_index_continues` | chunk_index starts at `start_chunk_index` |
+
+#### Section: Full Process Flow (with `pd.read_excel` mocked)
+
+| # | Test name | What it verifies |
+|---|---|---|
+| 31 | `test_process_single_sheet_happy_path` | DB table created, vector upserted, ProcessingResult fields correct |
+| 32 | `test_process_result_ingestion_method` | `result.ingestion_method == IngestionMethod.SQL_AGENT` (enum member) |
+| 33 | `test_process_chunk_metadata_ingestion_method` | metadata value is `"sql_agent"` (string) |
+| 34 | `test_process_chunk_metadata_parser_used` | metadata value is `"openpyxl"` (string) |
+| 35 | `test_process_written_artifacts_populated` | `written.db_table_names` and `written.vector_point_ids` non-empty |
+| 36 | `test_process_written_artifacts_collection` | `written.vector_collection == "helpdesk"` (from config default) |
+| 37 | `test_process_source_uri_format` | ChunkMetadata.source_uri starts with `"file://"` |
+| 38 | `test_process_db_uri_from_backend` | ChunkMetadata.db_uri matches `mock_db.get_connection_uri()` |
+| 39 | `test_process_embed_result_populated` | `result.embed_result` is not None, texts_embedded > 0 |
+| 40 | `test_process_tables_created_count` | `result.tables_created == 1` for single sheet |
+| 41 | `test_process_chunks_created_count_schema_only` | With row_serialization_limit=0, only schema chunk counted |
+| 42 | `test_process_tenant_id_passed_through` | ChunkMetadata.tenant_id and result.tenant_id match config |
+
+#### Section: Row Serialization Integration (triggers / skips)
+
+| # | Test name | What it verifies |
+|---|---|---|
+| 43 | `test_process_row_serialization_below_limit` | With 3 rows and limit=5000, schema + 3 row chunks = 4 total |
+| 44 | `test_process_row_serialization_above_limit` | With 100 rows and limit=50, only schema chunk = 1 total |
+| 45 | `test_process_row_serialization_batch_embedding` | With 130 rows and batch_size=64, embedder called 3 times (1 schema + 2 row batches) |
+
+#### Section: Multi-Sheet Processing
+
+| # | Test name | What it verifies |
+|---|---|---|
+| 46 | `test_process_multi_sheet` | 2 sheets -> 2 tables, 2+ chunks, both table names in written |
+| 47 | `test_process_multi_sheet_chunk_index_global` | chunk_index is global across sheets (sheet2 schema chunk continues from sheet1 last index) |
+| 48 | `test_process_duplicate_sheet_names_deduped` | Two sheets named "Data" -> tables "data" and "data_1" |
+
+#### Section: Sheet Skipping
+
+| # | Test name | What it verifies |
+|---|---|---|
+| 49 | `test_process_skips_hidden_sheet` | Hidden sheet skipped, warning `"W_SHEET_SKIPPED_HIDDEN"` added |
+| 50 | `test_process_skips_oversized_sheet` | Sheet with row_count > max_rows_in_memory skipped, warning added |
+| 51 | `test_process_all_sheets_skipped_empty_result` | All sheets skipped -> tables_created=0, chunks_created=0 |
+
+#### Section: Error Handling
+
+| # | Test name | What it verifies |
+|---|---|---|
+| 52 | `test_process_db_failure_records_error` | DB exception -> errors list contains error code, error_details has IngestError |
+| 53 | `test_process_db_failure_continues_to_next_sheet` | Sheet 1 DB fails, Sheet 2 succeeds -> 1 table, 1 error |
+| 54 | `test_process_embed_failure_records_error` | Embedder exception -> error recorded |
+| 55 | `test_process_error_details_stage_is_process` | IngestError.stage == "process" |
+| 56 | `test_process_error_details_has_sheet_name` | IngestError.sheet_name populated |
+
+#### Section: Config Interactions
+
+| # | Test name | What it verifies |
+|---|---|---|
+| 57 | `test_process_clean_column_names_disabled` | config.clean_column_names=False -> columns NOT cleaned |
+| 58 | `test_process_custom_collection` | config.default_collection="custom" -> used in ensure_collection and upserts |
+
+### 7.6 Test implementation pattern for `process()` tests
+
+All `process()` tests must mock `pd.read_excel` since they do not use real files:
+
+```python
+@patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+def test_process_single_sheet_happy_path(
+    mock_read_excel, processor, mock_db, mock_vector_store, mock_embedder,
+):
+    df = pd.DataFrame({"id": [1, 2, 3], "name": ["Alice", "Bob", "Carol"]})
+    mock_read_excel.return_value = df
+
+    sheet = _make_sheet_profile(name="Employees", row_count=3, col_count=2)
+    profile = _make_file_profile([sheet])
+    parse_result = _make_parse_result()
+    classification_stage = _make_classification_stage_result()
+    classification = _make_classification_result()
+
+    result = processor.process(
+        file_path="/tmp/test.xlsx",
+        profile=profile,
+        ingest_key="abc123" * 10 + "abcd",
+        ingest_run_id="550e8400-e29b-41d4-a716-446655440000",
+        parse_result=parse_result,
+        classification_result=classification_stage,
+        classification=classification,
+    )
+
+    # Verify DB interaction
+    assert len(mock_db.tables_created) == 1
+    assert mock_db.tables_created[0][0] == "employees"
+
+    # Verify vector store interaction
+    assert len(mock_vector_store.upserted) >= 1
+    assert mock_vector_store.collections_ensured[0] == ("helpdesk", 768)
+
+    # Verify result structure
+    assert result.ingestion_method == IngestionMethod.SQL_AGENT
+    assert result.tables_created == 1
+    assert result.tables == ["employees"]
+    assert result.written.db_table_names == ["employees"]
+    assert len(result.written.vector_point_ids) >= 1
+    assert result.written.vector_collection == "helpdesk"
+    assert result.errors == []
+    assert result.processing_time_seconds > 0
+```
+
+---
+
+## 8. Implementation Order
+
+1. **Create `src/ingestkit_excel/processors/__init__.py`** -- minimal, just the re-export
+2. **Create `src/ingestkit_excel/processors/structured_db.py`** -- module-level helpers first (`clean_name`, `deduplicate_names`), then the class with all methods
+3. **Create `tests/test_structured_db.py`** -- all tests
+4. **Update `src/ingestkit_excel/__init__.py`** -- add `StructuredDBProcessor` to imports and `__all__`
+5. **Run tests** -- `pytest tests/test_structured_db.py -v`
+
+---
+
+## 9. Critical Implementation Notes
+
+### 9.1 ENUM_VALUE Pattern Prevention
+
+- `ChunkMetadata.ingestion_method` MUST be `IngestionMethod.SQL_AGENT.value` which is `"sql_agent"` -- NOT `"SQL_AGENT"`
+- `ProcessingResult.ingestion_method` MUST be `IngestionMethod.SQL_AGENT` (the enum member itself) -- the field type is `IngestionMethod`, not `str`
+- `ChunkMetadata.parser_used` MUST use `sheet.parser_used.value` (e.g. `"openpyxl"`) -- NOT `"OPENPYXL"`
+- Error/warning strings in `ProcessingResult.errors` and `ProcessingResult.warnings` MUST use `ErrorCode.*.value` (e.g. `"W_SHEET_SKIPPED_HIDDEN"`)
+
+### 9.2 COMPONENT_API Pattern Prevention
+
+- `VectorStoreBackend.upsert_chunks(collection, chunks)` -- NOT `upsert(collection, chunks)`
+- `EmbeddingBackend.embed(texts, timeout=...)` -- returns `list[list[float]]`, NOT `list[float]`
+- `StructuredDBBackend.create_table_from_dataframe(table_name, df)` -- returns `None`
+- `EmbeddingBackend.dimension()` -- method call with parens, NOT property
+
+### 9.3 VERIFICATION_GAP Prevention
+
+- `ProcessingResult` requires `parse_result` and `classification_result` (no defaults) -- the processor MUST accept and pass them through
+- `ProcessingResult.classification` is a separate field from `classification_result` -- it uses `ClassificationResult` (simpler model), not `ClassificationStageResult`
+- `WrittenArtifacts.vector_point_ids` is `list[str]`, append individual `str` IDs
+- `SheetProfile.header_row_index` is `int | None` -- use it as the `header` arg for `pd.read_excel`
+- `ChunkPayload.vector` is `list[float]` -- cannot be `None`, use `[]` as placeholder for row chunks before embedding
+
+### 9.4 pandas Version Note
+
+The project uses Python 3.12 which means pandas >= 2.0 is required. Use `format="mixed"` instead of the deprecated `infer_datetime_format=True` parameter in `pd.to_datetime()`.
+
+### 9.5 source_uri Convention
+
+Use `f"file://{Path(file_path).resolve().as_posix()}"` to match the SPEC example format `"file:///path/to/roster.xlsx"`. This differs slightly from `idempotency.py` which uses just the POSIX path without `file://`, but the processor follows the SPEC section 10.1 convention for ChunkMetadata.
+
+### 9.6 Table Name Deduplication
+
+Table names must be deduplicated across sheets within a single `process()` call. If two sheets both clean to the same table name, append `_1`, `_2`, etc. This uses a simpler approach than `deduplicate_names` since it is across a growing list rather than a batch.
+
+### 9.7 Global chunk_index
+
+The `chunk_index` counter is global across all sheets in a single `process()` invocation. It does NOT reset per sheet. This ensures every chunk has a unique index within the result.

--- a/.agents/outputs/plan-check-8-021026.md
+++ b/.agents/outputs/plan-check-8-021026.md
@@ -1,0 +1,590 @@
+# PLAN-CHECK: Issue #8 — Path A Structured DB Processor
+
+**Issue:** #8
+**Plan artifact:** `plan-8-021026.md`
+**Map artifact:** `map-8-021026.md`
+**Date:** 2026-02-11
+**Validator:** Claude Code PLAN-CHECK agent
+**Status:** **PASS** ✓
+
+---
+
+## Executive Summary
+
+The PLAN for Issue #8 (Path A Structured DB Processor) is **VALIDATED** against all sources of truth. All enum values, model field names, protocol signatures, config fields, processing steps, and test coverage align with the actual codebase.
+
+No blocking issues found. The plan is ready for IMPLEMENT.
+
+---
+
+## Validation Results by Criterion
+
+### 1. Enum VALUES Used Correctly ✓
+
+**Criterion:** `IngestionMethod.SQL_AGENT` value is `"sql_agent"` (not `"SQL_AGENT"`)
+
+**Verification:**
+
+From `/home/jjob/projects/ingestkit/packages/ingestkit-excel/src/ingestkit_excel/models.py` lines 48-57:
+
+```python
+class IngestionMethod(str, Enum):
+    """Processing path used after classification."""
+    SQL_AGENT = "sql_agent"
+    TEXT_SERIALIZATION = "text_serialization"
+    HYBRID_SPLIT = "hybrid_split"
+```
+
+**Status:** ✓ PASS
+- Plan references `IngestionMethod.SQL_AGENT.value` which evaluates to `"sql_agent"` (correct lowercase)
+- Plan references enum member `IngestionMethod.SQL_AGENT` for `ProcessingResult.ingestion_method` (correct type)
+- Plan correctly uses `.value` for metadata string fields
+
+**Related enums validated:**
+
+| Enum | Expected Value | Actual Value | Status |
+|------|---|---|---|
+| `ParserUsed.OPENPYXL` | `"openpyxl"` | `"openpyxl"` | ✓ |
+| `FileType.TABULAR_DATA` | `"tabular_data"` | `"tabular_data"` | ✓ |
+| `ClassificationTier.RULE_BASED` | `"rule_based"` | `"rule_based"` | ✓ |
+| `ErrorCode.W_SHEET_SKIPPED_HIDDEN` | `"W_SHEET_SKIPPED_HIDDEN"` | (confirmed via errors.py) | ✓ |
+| `ErrorCode.E_BACKEND_DB_TIMEOUT` | `"E_BACKEND_DB_TIMEOUT"` | (confirmed via errors.py) | ✓ |
+
+---
+
+### 2. ChunkMetadata Field Names Match ✓
+
+**Criterion:** All ChunkMetadata fields used in the plan exist in the actual model
+
+**Verification:**
+
+From `/home/jjob/projects/ingestkit/packages/ingestkit-excel/src/ingestkit_excel/models.py` lines 195-219:
+
+```python
+class ChunkMetadata(BaseModel):
+    source_uri: str
+    source_format: str = "xlsx"
+    sheet_name: str
+    region_id: str | None = None
+    ingestion_method: str
+    parser_used: str
+    parser_version: str
+    chunk_index: int
+    chunk_hash: str
+    ingest_key: str
+    ingest_run_id: str
+    tenant_id: str | None = None
+    table_name: str | None = None
+    db_uri: str | None = None
+    row_count: int | None = None
+    columns: list[str] | None = None
+    section_title: str | None = None
+    original_structure: str | None = None
+```
+
+**Plan field usage in ChunkMetadata:**
+
+| Field | Plan usage | Type | Status |
+|-------|-----------|------|--------|
+| `source_uri` | Schema chunks + row chunks | `str` | ✓ |
+| `source_format` | Schema chunks + row chunks | `str` | ✓ |
+| `sheet_name` | Schema chunks + row chunks | `str` | ✓ |
+| `region_id` | Set to `None` (Path A) | `str \| None` | ✓ |
+| `ingestion_method` | `"sql_agent"` | `str` | ✓ |
+| `parser_used` | `sheet.parser_used.value` | `str` | ✓ |
+| `parser_version` | `config.parser_version` | `str` | ✓ |
+| `chunk_index` | Global counter | `int` | ✓ |
+| `chunk_hash` | SHA-256 hash | `str` | ✓ |
+| `ingest_key` | Parameter | `str` | ✓ |
+| `ingest_run_id` | Parameter | `str` | ✓ |
+| `tenant_id` | `config.tenant_id` | `str \| None` | ✓ |
+| `table_name` | Cleaned sheet name | `str \| None` | ✓ |
+| `db_uri` | `self._db.get_connection_uri()` | `str \| None` | ✓ |
+| `row_count` | `len(df)` | `int \| None` | ✓ |
+| `columns` | `list(df.columns)` | `list[str] \| None` | ✓ |
+| `section_title` | `None` (Path B only) | `str \| None` | ✓ |
+| `original_structure` | `None` (Path B only) | `str \| None` | ✓ |
+
+**Status:** ✓ PASS — All 18 fields exist with correct types.
+
+---
+
+### 3. ProcessingResult Field Names Match ✓
+
+**Criterion:** All ProcessingResult fields used in the plan exist in the actual model
+
+**Verification:**
+
+From `/home/jjob/projects/ingestkit/packages/ingestkit-excel/src/ingestkit_excel/models.py` lines 253-277:
+
+```python
+class ProcessingResult(BaseModel):
+    file_path: str
+    ingest_key: str
+    ingest_run_id: str
+    tenant_id: str | None = None
+    parse_result: ParseStageResult
+    classification_result: ClassificationStageResult
+    embed_result: EmbedStageResult | None = None
+    classification: ClassificationResult
+    ingestion_method: IngestionMethod
+    chunks_created: int
+    tables_created: int
+    tables: list[str]
+    written: WrittenArtifacts
+    errors: list[str]
+    warnings: list[str]
+    error_details: list[IngestError] = []
+    processing_time_seconds: float
+```
+
+**Plan field usage:**
+
+| Field | Plan usage | Type | Status |
+|-------|-----------|------|--------|
+| `file_path` | Passed from parameter | `str` | ✓ |
+| `ingest_key` | Passed from parameter | `str` | ✓ |
+| `ingest_run_id` | Passed from parameter | `str` | ✓ |
+| `tenant_id` | `config.tenant_id` | `str \| None` | ✓ |
+| `parse_result` | **Passed as parameter** (§14 of plan) | `ParseStageResult` | ✓ |
+| `classification_result` | **Passed as parameter** (§14 of plan) | `ClassificationStageResult` | ✓ |
+| `embed_result` | Built from embedding metrics | `EmbedStageResult \| None` | ✓ |
+| `classification` | **Passed as parameter** (§14 of plan) | `ClassificationResult` | ✓ |
+| `ingestion_method` | `IngestionMethod.SQL_AGENT` (enum member) | `IngestionMethod` | ✓ |
+| `chunks_created` | Counter (total chunks upserted) | `int` | ✓ |
+| `tables_created` | `len(tables)` | `int` | ✓ |
+| `tables` | List of table names | `list[str]` | ✓ |
+| `written` | `WrittenArtifacts` instance | `WrittenArtifacts` | ✓ |
+| `errors` | List of error code strings | `list[str]` | ✓ |
+| `warnings` | List of warning code strings | `list[str]` | ✓ |
+| `error_details` | List of `IngestError` objects | `list[IngestError]` | ✓ |
+| `processing_time_seconds` | Measured elapsed time | `float` | ✓ |
+
+**Critical note on optional parameters:** The plan (§14) correctly identifies that `ProcessingResult` **requires** `parse_result` and `classification_result` with no defaults. The plan appropriately recommends accepting these as additional parameters to the `process()` method signature beyond the SPEC's minimum. This is explicitly noted in plan sections 3.3 and 9.1.
+
+**Status:** ✓ PASS — All 17 fields exist with correct types. Design decision about additional parameters is documented.
+
+---
+
+### 4. WrittenArtifacts Field Names Match ✓
+
+**Criterion:** All WrittenArtifacts fields used in the plan exist in the actual model
+
+**Verification:**
+
+From `/home/jjob/projects/ingestkit/packages/ingestkit-excel/src/ingestkit_excel/models.py` lines 245-250:
+
+```python
+class WrittenArtifacts(BaseModel):
+    """IDs of everything written to backends, enabling caller-side rollback."""
+    vector_point_ids: list[str] = []
+    vector_collection: str | None = None
+    db_table_names: list[str] = []
+```
+
+**Plan field usage:**
+
+| Field | Plan usage | Type | Default | Status |
+|-------|-----------|------|---------|--------|
+| `vector_point_ids` | Append chunk IDs | `list[str]` | `[]` | ✓ |
+| `vector_collection` | Set to `config.default_collection` | `str \| None` | `None` | ✓ |
+| `db_table_names` | Append table names | `list[str]` | `[]` | ✓ |
+
+**Status:** ✓ PASS — All 3 fields exist with correct types and defaults.
+
+---
+
+### 5. Protocol Method Signatures Match ✓
+
+**Criterion:** All protocol methods called by the plan match actual signatures
+
+**Verification:**
+
+From `/home/jjob/projects/ingestkit/packages/ingestkit-excel/src/ingestkit_excel/protocols.py`:
+
+**StructuredDBBackend (lines 40-61):**
+
+```python
+@runtime_checkable
+class StructuredDBBackend(Protocol):
+    def create_table_from_dataframe(self, table_name: str, df: pd.DataFrame) -> None: ...
+    def drop_table(self, table_name: str) -> None: ...
+    def table_exists(self, table_name: str) -> bool: ...
+    def get_table_schema(self, table_name: str) -> dict: ...
+    def get_connection_uri(self) -> str: ...
+```
+
+**Plan usage:**
+
+| Method | Plan call | Expected signature | Actual signature | Status |
+|--------|-----------|---|---|---|
+| `create_table_from_dataframe` | `self._db.create_table_from_dataframe(table_name, df)` | `(str, pd.DataFrame) -> None` | `(str, pd.DataFrame) -> None` | ✓ |
+| `get_connection_uri` | `self._db.get_connection_uri()` | `() -> str` | `() -> str` | ✓ |
+
+**VectorStoreBackend (lines 19-36):**
+
+```python
+@runtime_checkable
+class VectorStoreBackend(Protocol):
+    def upsert_chunks(self, collection: str, chunks: list[ChunkPayload]) -> int: ...
+    def ensure_collection(self, collection: str, vector_size: int) -> None: ...
+    def create_payload_index(self, collection: str, field: str, field_type: str) -> None: ...
+    def delete_by_ids(self, collection: str, ids: list[str]) -> int: ...
+```
+
+**Plan usage:**
+
+| Method | Plan call | Expected signature | Actual signature | Status |
+|--------|-----------|---|---|---|
+| `ensure_collection` | `self._vector_store.ensure_collection(collection, vector_size)` | `(str, int) -> None` | `(str, int) -> None` | ✓ |
+| `upsert_chunks` | `self._vector_store.upsert_chunks(collection, [chunk])` | `(str, list[ChunkPayload]) -> int` | `(str, list[ChunkPayload]) -> int` | ✓ |
+
+**EmbeddingBackend (lines 89-101):**
+
+```python
+@runtime_checkable
+class EmbeddingBackend(Protocol):
+    def embed(self, texts: list[str], timeout: float | None = None) -> list[list[float]]: ...
+    def dimension(self) -> int: ...
+```
+
+**Plan usage:**
+
+| Method | Plan call | Expected signature | Actual signature | Status |
+|--------|-----------|---|---|---|
+| `embed` | `self._embedder.embed([schema_text], timeout=config.backend_timeout_seconds)` | `(list[str], timeout=float\|None) -> list[list[float]]` | `(list[str], timeout=float\|None) -> list[list[float]]` | ✓ |
+| `dimension` | `self._embedder.dimension()` | `() -> int` | `() -> int` | ✓ |
+
+**Status:** ✓ PASS — All 6 protocol methods match expected signatures exactly.
+
+---
+
+### 6. Config Field Names Match ✓
+
+**Criterion:** All config fields used in the plan exist in the actual config class
+
+**Verification:**
+
+From `/home/jjob/projects/ingestkit/packages/ingestkit-excel/src/ingestkit_excel/config.py` lines 16-69:
+
+```python
+class ExcelProcessorConfig(BaseModel):
+    parser_version: str = "ingestkit_excel:1.0.0"
+    tenant_id: str | None = None
+    tier1_high_confidence_signals: int = 4
+    tier1_medium_confidence_signals: int = 3
+    merged_cell_ratio_threshold: float = 0.05
+    numeric_ratio_threshold: float = 0.3
+    column_consistency_threshold: float = 0.7
+    min_row_count_for_tabular: int = 5
+    classification_model: str = "qwen2.5:7b"
+    reasoning_model: str = "deepseek-r1:14b"
+    tier2_confidence_threshold: float = 0.6
+    llm_temperature: float = 0.1
+    row_serialization_limit: int = 5000
+    clean_column_names: bool = True
+    embedding_model: str = "nomic-embed-text"
+    embedding_dimension: int = 768
+    embedding_batch_size: int = 64
+    default_collection: str = "helpdesk"
+    max_sample_rows: int = 3
+    enable_tier3: bool = True
+    max_rows_in_memory: int = 100_000
+    backend_timeout_seconds: float = 30.0
+    backend_max_retries: int = 2
+    backend_backoff_base: float = 1.0
+    log_sample_data: bool = False
+    log_llm_prompts: bool = False
+    log_chunk_previews: bool = False
+    redact_patterns: list[str] = []
+```
+
+**Plan field usage:**
+
+| Field | Plan usage | Type | Default | Status |
+|-------|-----------|------|---------|--------|
+| `parser_version` | ChunkMetadata.parser_version | `str` | `"ingestkit_excel:1.0.0"` | ✓ |
+| `tenant_id` | ChunkMetadata.tenant_id, ProcessingResult.tenant_id | `str \| None` | `None` | ✓ |
+| `row_serialization_limit` | Condition for row serialization | `int` | `5000` | ✓ |
+| `clean_column_names` | Condition for column cleaning | `bool` | `True` | ✓ |
+| `embedding_dimension` | For `ensure_collection` vector_size | `int` | `768` | ✓ |
+| `embedding_batch_size` | Batch embedding loop | `int` | `64` | ✓ |
+| `default_collection` | Collection name for ensure/upsert | `str` | `"helpdesk"` | ✓ |
+| `backend_timeout_seconds` | Timeout for backend calls | `float` | `30.0` | ✓ |
+| `max_rows_in_memory` | Skip condition for sheets | `int` | `100_000` | ✓ |
+
+**Status:** ✓ PASS — All 9 config fields used in the plan exist with correct types and defaults.
+
+---
+
+### 7. Processing Steps Match SPEC §10.1 ✓
+
+**Criterion:** All 7 processing steps in the plan align with SPEC section 10.1
+
+**Verification:**
+
+From `/home/jjob/projects/ingestkit/packages/ingestkit-excel/SPEC.md` lines 697-734:
+
+**SPEC Step 1 — Load each sheet:**
+- Plan Step 1 ✓: `pd.read_excel(file_path, sheet_name=sheet.name, header=header_arg)`
+
+**SPEC Step 2 — Clean column names:**
+- Plan Step 2 ✓: Implements `clean_name()` + `deduplicate_names()` with exact rules (lowercase, special char replacement, underscore collapse, dedup)
+
+**SPEC Step 3 — Auto-detect dates:**
+- Plan Step 3 ✓: Two heuristics (Excel serial dates 35k-55k, string dates >50% parse rate), uses `pd.to_datetime()` with `format="mixed"` (modern pandas >=2.0)
+
+**SPEC Step 4 — Write to DB:**
+- Plan Step 4 ✓: Calls `structured_db.create_table_from_dataframe(table_name, df)`, tracks in `WrittenArtifacts.db_table_names`, handles table name deduplication
+
+**SPEC Step 5 — Generate schema description:**
+- Plan Step 5 ✓: Format matches SPEC example with table name, row count, column descriptions (type + cardinality/range information)
+
+**SPEC Step 6 — Embed schema + upsert:**
+- Plan Step 6 ✓: Calls `embedder.embed([schema_text])`, builds `ChunkMetadata`, creates `ChunkPayload` with deterministic UUID5 ID, upserts via `vector_store.upsert_chunks()`
+
+**SPEC Step 7 — Optional row serialization:**
+- Plan Step 7 ✓: Condition `len(df) < config.row_serialization_limit`, serializes rows as natural language sentences, batch embeds with `config.embedding_batch_size`, upserts individual chunks
+
+**Status:** ✓ PASS — All 7 steps map 1:1 to SPEC with no deviations.
+
+---
+
+### 8. Test Coverage Is Sufficient ✓
+
+**Criterion:** Test plan covers all major functional areas
+
+**Verification:**
+
+Plan §7.5 lists 58 test cases across 8 sections:
+
+| Section | # Cases | Coverage |
+|---------|---------|----------|
+| Column Name Cleaning | 11 | `clean_name()`, `deduplicate_names()`, edge cases (unicode, empty, numeric) |
+| Date Detection | 6 | Excel serial dates, string dates, heuristic boundaries, mixed data |
+| Schema Description | 8 | Table name, integer/float/text/date/boolean columns, cardinality detection |
+| Row Serialization | 5 | Format, NaN handling, metadata correctness, deterministic IDs, index continuation |
+| Full Process Flow | 12 | Happy path, enum values, field population, written artifacts, DB/vector URIs, collection name, error details |
+| Row Serialization Integration | 3 | Below/above limit triggers, batch embedding |
+| Multi-Sheet Processing | 3 | Multi-sheet flow, global chunk index, duplicate sheet name deduplication |
+| Sheet Skipping | 3 | Hidden sheets, oversized sheets, all-skipped result |
+| Error Handling | 5 | DB/embed failures, error details structure, stage field, sheet name tracking |
+| Config Interactions | 2 | Column cleaning disabled, custom collection |
+
+**Total: 58 test cases covering:**
+- ✓ Unit tests for helper functions (clean_name, deduplicate_names)
+- ✓ Unit tests for private methods (_auto_detect_dates, _generate_schema_description, _serialize_rows, _classify_backend_error)
+- ✓ Integration tests for full process() flow with mocked backends
+- ✓ Edge cases (all sheets skipped, custom config values)
+- ✓ Error paths (per-sheet failures with continuation)
+- ✓ Enum value correctness (ingestion_method, parser_used, error codes)
+- ✓ Model field correctness (ChunkMetadata, ProcessingResult, WrittenArtifacts)
+
+**Test structure:**
+- ✓ Fixtures for config, mocks (MockStructuredDB, MockVectorStore, MockEmbedder)
+- ✓ Helper factories for test data (_make_sheet_profile, _make_file_profile, _make_parse_result, _make_classification_stage_result, _make_classification_result)
+- ✓ All process() tests mock pd.read_excel (no real files needed)
+
+**Status:** ✓ PASS — Test coverage is comprehensive and well-organized.
+
+---
+
+## Critical Implementation Notes Validation
+
+### ENUM_VALUE Pattern Prevention ✓
+
+Plan §9.1 correctly specifies:
+- ✓ `ChunkMetadata.ingestion_method` = `IngestionMethod.SQL_AGENT.value` = `"sql_agent"` (not `"SQL_AGENT"`)
+- ✓ `ProcessingResult.ingestion_method` = `IngestionMethod.SQL_AGENT` (enum member, not string)
+- ✓ `ChunkMetadata.parser_used` = `sheet.parser_used.value` (e.g. `"openpyxl"`)
+- ✓ Error/warning list entries use `ErrorCode.*.value` (e.g. `"W_SHEET_SKIPPED_HIDDEN"`)
+
+All match actual enum definitions.
+
+### COMPONENT_API Pattern Prevention ✓
+
+Plan §9.2 correctly specifies:
+- ✓ `VectorStoreBackend.upsert_chunks(collection, chunks)` — signature matches protocols.py
+- ✓ `EmbeddingBackend.embed(texts, timeout=...)` returns `list[list[float]]` — matches protocols.py
+- ✓ `StructuredDBBackend.create_table_from_dataframe(table_name, df)` returns `None` — matches protocols.py
+- ✓ `EmbeddingBackend.dimension()` is a method call with parens — matches protocols.py
+
+### VERIFICATION_GAP Pattern Prevention ✓
+
+Plan §9.3 correctly specifies:
+- ✓ `SheetProfile.header_row_index: int | None` exists (line 157 of models.py)
+- ✓ `ProcessingResult` requires `parse_result` and `classification_result` (lines 261-262, no defaults)
+- ✓ `ProcessingResult.classification` is separate from `classification_result` (line 265, `ClassificationResult` not `ClassificationStageResult`)
+- ✓ `WrittenArtifacts.vector_point_ids: list[str]`, append individual strings (line 248)
+- ✓ `ChunkPayload.vector: list[float]`, cannot be `None`, use `[]` as placeholder (line 227)
+
+### pandas Version Compatibility ✓
+
+Plan §9.4 correctly notes:
+- ✓ Project uses Python 3.12 (inferred from dependencies)
+- ✓ pandas >= 2.0 required (inferred)
+- ✓ Use `format="mixed"` instead of deprecated `infer_datetime_format=True`
+- ✓ This is implemented in plan §3.4 method `_auto_detect_dates()` at line 406
+
+### source_uri Convention ✓
+
+Plan §9.5 specifies:
+- ✓ Use `f"file://{Path(file_path).resolve().as_posix()}"` format (matches SPEC example §10.1)
+- ✓ This differs from idempotency.py pattern but aligns with SPEC
+
+### Table Name Deduplication ✓
+
+Plan §9.6 correctly specifies:
+- ✓ Per-ingest deduplication across growing sheet list
+- ✓ Algorithm: if table_name already in tables list, append _1, _2, etc.
+
+### Global chunk_index ✓
+
+Plan §9.7 correctly specifies:
+- ✓ Counter is global across all sheets in single process() call
+- ✓ Does NOT reset per sheet
+- ✓ Ensures unique indexes within result
+
+---
+
+## Signature and Interface Verification
+
+### process() Method Signature
+
+**Plan (§3.3, line 150-159):**
+```python
+def process(
+    self,
+    file_path: str,
+    profile: FileProfile,
+    ingest_key: str,
+    ingest_run_id: str,
+    parse_result: ParseStageResult,
+    classification_result: ClassificationStageResult,
+    classification: ClassificationResult,
+) -> ProcessingResult:
+```
+
+**Rationale for additional parameters:** Plan §14 (lines 693-702) explains that SPEC minimum signature does not include `parse_result`, `classification_result`, and `classification`, but `ProcessingResult` requires them. The plan appropriately adds them as parameters, which is the recommended approach per §14 analysis.
+
+**Status:** ✓ Design decision documented and justified.
+
+### Constructor Signature
+
+**Plan (§3.3, lines 133-143):**
+```python
+def __init__(
+    self,
+    structured_db: StructuredDBBackend,
+    vector_store: VectorStoreBackend,
+    embedder: EmbeddingBackend,
+    config: ExcelProcessorConfig,
+) -> None:
+```
+
+**Status:** ✓ Matches protocol usage pattern.
+
+---
+
+## Data Flow Verification
+
+### Metadata Assembly — Consistent Pattern ✓
+
+All ChunkMetadata instances in the plan (both schema chunks and row chunks) follow the same template:
+- source_uri, source_format, sheet_name, region_id, parser_used, parser_version, ingest_key, ingest_run_id, tenant_id — all sourced consistently
+- Path A specific fields (table_name, db_uri, row_count, columns) — populated correctly
+- Path B specific fields (section_title, original_structure) — set to None correctly
+
+### Error Handling — Consistent Pattern ✓
+
+Plan §3.3 (lines 323-335) shows per-sheet error handling with:
+- `_classify_backend_error()` returning appropriate ErrorCode
+- Appending `error_code.value` to errors list
+- Creating IngestError with all required fields
+- Continuing to next sheet (non-fatal)
+
+---
+
+## Implementation Order Validation
+
+Plan §8 specifies order:
+1. Create processors/__init__.py
+2. Create processors/structured_db.py (helpers first, then class)
+3. Create tests/test_structured_db.py
+4. Update __init__.py (add processor to API)
+5. Run tests
+
+**Status:** ✓ Logical and testable order.
+
+---
+
+## File Creation vs. Modification
+
+**Plan impact analysis:**
+- ✓ **NEW files:** `src/ingestkit_excel/processors/__init__.py`, `src/ingestkit_excel/processors/structured_db.py`, `tests/test_structured_db.py`
+- ✓ **MODIFIED files:** `src/ingestkit_excel/__init__.py` (add import + __all__ entry)
+- ✓ **UNAFFECTED files:** All other modules remain unchanged
+
+---
+
+## Notation and Clarity
+
+All pseudocode, method signatures, and code examples in the plan:
+- ✓ Use correct Python 3.12+ syntax (Union via `|`, TypeAlias via `type` if needed)
+- ✓ Use `from __future__ import annotations` for forward references
+- ✓ Use Pydantic v2 `BaseModel` API
+- ✓ Use runtime_checkable Protocol types correctly
+
+---
+
+## Final Checklist
+
+| Item | Status |
+|------|--------|
+| ✓ Enum values (STRING, not PYTHON_NAME) | PASS |
+| ✓ ChunkMetadata field names | PASS |
+| ✓ ProcessingResult field names | PASS |
+| ✓ WrittenArtifacts field names | PASS |
+| ✓ Protocol method signatures | PASS |
+| ✓ Config field names and defaults | PASS |
+| ✓ Processing steps align with SPEC §10.1 | PASS |
+| ✓ Test coverage sufficient | PASS |
+| ✓ ENUM_VALUE pattern prevention | PASS |
+| ✓ COMPONENT_API pattern prevention | PASS |
+| ✓ VERIFICATION_GAP pattern prevention | PASS |
+| ✓ pandas version compatibility | PASS |
+| ✓ source_uri convention | PASS |
+| ✓ Table name deduplication logic | PASS |
+| ✓ Global chunk_index semantics | PASS |
+| ✓ process() signature design rationale | PASS |
+| ✓ Constructor signature | PASS |
+| ✓ Error handling pattern | PASS |
+| ✓ Implementation order | PASS |
+| ✓ File modification scope | PASS |
+
+---
+
+## Conclusion
+
+**FINAL VERDICT: PASS** ✓
+
+The PLAN for Issue #8 is **ready for IMPLEMENT**. All validation criteria are met:
+
+1. Enum values are correctly sourced and used (no Python name conflicts).
+2. All model field names and types match actual definitions.
+3. All protocol method signatures match.
+4. All config field names and defaults align.
+5. All 7 processing steps map to SPEC §10.1 without deviation.
+6. Test coverage is comprehensive (58 cases across 9 areas).
+7. Critical failure patterns (ENUM_VALUE, COMPONENT_API, VERIFICATION_GAP) are explicitly prevented.
+8. Design decisions (parse_result/classification_result as parameters) are documented and justified.
+9. No blocking issues or inconsistencies found.
+
+The IMPLEMENT agent can proceed with confidence that the plan is correct, complete, and internally consistent.
+
+---
+
+**Validated by:** Claude Code PLAN-CHECK agent
+**Date:** 2026-02-11
+**Time:** N/A (batch validation)
+**Status:** APPROVED FOR IMPLEMENTATION

--- a/.agents/outputs/prove-8-021026.md
+++ b/.agents/outputs/prove-8-021026.md
@@ -1,0 +1,147 @@
+# PROVE: Issue #8 -- Path A Structured DB Processor
+
+**Result: PASS**
+
+**Date:** 2026-02-11
+**Package:** ingestkit-excel
+**Agent:** prove
+
+---
+
+## 1. Test Suite
+
+**Status: PASS**
+
+```
+335 passed in 0.45s
+```
+
+All 335 tests pass, including 50+ tests in `test_structured_db.py` covering the new Path A processor.
+
+---
+
+## 2. File Structure
+
+**Status: PASS**
+
+| File | Exists | Verified |
+|------|--------|----------|
+| `src/ingestkit_excel/processors/__init__.py` | Yes | Exports `StructuredDBProcessor` in `__all__` |
+| `src/ingestkit_excel/processors/structured_db.py` | Yes | 559 lines, complete implementation |
+| `tests/test_structured_db.py` | Yes | 1459 lines, comprehensive coverage |
+| `src/ingestkit_excel/__init__.py` | Yes | Re-exports `StructuredDBProcessor` at package level |
+
+---
+
+## 3. Implementation Verification (`structured_db.py`)
+
+**Status: PASS**
+
+| Requirement | Present | Details |
+|-------------|---------|---------|
+| `clean_name()` module-level helper | Yes | L43-56. Lowercase, regex non-alnum->underscore, collapse, strip |
+| `deduplicate_names()` module-level helper | Yes | L59-75. Appends `_1`, `_2` etc.; empty names become `column_N` |
+| `StructuredDBProcessor` class | Yes | L83-559. Takes structured_db, vector_store, embedder, config |
+| `process()` method returning `ProcessingResult` | Yes | L105-341. Full pipeline: load -> clean -> detect dates -> DB write -> schema -> embed -> optional row serialize |
+| Column cleaning | Yes | L183-186. Controlled by `config.clean_column_names` |
+| Date detection | Yes | L347-400. `_auto_detect_dates()`: Excel serial dates (35000-55000 range) and string dates (>50% threshold) |
+| Schema generation | Yes | L402-463. `_generate_schema_description()`: NL description with type-aware column stats |
+| Row serialization | Yes | L465-535. `_serialize_rows()`: NL sentence per row, batch embedding |
+| WrittenArtifacts tracking | Yes | L140, L203, L253, L289. Tracks db_table_names, vector_point_ids, vector_collection |
+| Error handling (per-sheet continue) | Yes | L294-310. Catches exceptions, classifies error codes, continues to next sheet |
+
+---
+
+## 4. ENUM_VALUE Verification (CRITICAL)
+
+**Status: PASS**
+
+The `IngestionMethod` enum is defined as:
+```python
+class IngestionMethod(str, Enum):
+    SQL_AGENT = "sql_agent"
+```
+
+Usage in `structured_db.py`:
+
+| Location | Code | Target Field Type | Correct? |
+|----------|------|-------------------|----------|
+| L232 (ChunkMetadata) | `IngestionMethod.SQL_AGENT.value` | `str` | YES -- `.value` yields `"sql_agent"` |
+| L332 (ProcessingResult) | `IngestionMethod.SQL_AGENT` | `IngestionMethod` | YES -- enum member, not string |
+| L513 (row ChunkMetadata) | `IngestionMethod.SQL_AGENT.value` | `str` | YES -- `.value` yields `"sql_agent"` |
+
+Model field types confirmed:
+- `ChunkMetadata.ingestion_method: str` (L206 in models.py) -- receives `.value`
+- `ProcessingResult.ingestion_method: IngestionMethod` (L266 in models.py) -- receives enum member
+
+Tests explicitly verify this distinction:
+- `test_process_result_ingestion_method`: asserts `result.ingestion_method is IngestionMethod.SQL_AGENT` (identity check)
+- `test_process_chunk_metadata_ingestion_method`: asserts `chunk.metadata.ingestion_method == "sql_agent"` (string check)
+
+---
+
+## 5. Package Export Verification
+
+**Status: PASS**
+
+```python
+# src/ingestkit_excel/processors/__init__.py
+from ingestkit_excel.processors.structured_db import StructuredDBProcessor
+__all__ = ["StructuredDBProcessor"]
+
+# src/ingestkit_excel/__init__.py
+from ingestkit_excel.processors import StructuredDBProcessor
+# ... in __all__:
+"StructuredDBProcessor",
+```
+
+---
+
+## 6. Test Coverage Checklist
+
+**Status: PASS**
+
+| Coverage Area | Test Class(es) | Test Count |
+|---------------|----------------|------------|
+| Column name cleaning (spaces, special chars) | `TestCleanName` | 7 tests |
+| Column deduplication | `TestDeduplicateNames` | 4 tests |
+| Date detection (serial dates) | `TestAutoDetectDates` | 6 tests |
+| Date detection (string dates) | `TestAutoDetectDates` | 6 tests |
+| Schema description generation | `TestSchemaDescription` | 8 tests |
+| Row serialization format | `TestSerializeRows` | 5 tests |
+| DB write and vector upsert | `TestProcessFlow` | 13 tests |
+| WrittenArtifacts populated | `TestProcessFlow` | 2 tests |
+| Multi-sheet processing | `TestMultiSheetProcessing` | 3 tests |
+| Sheet skipping (hidden, oversized) | `TestSheetSkipping` | 3 tests |
+| Error handling (DB fail, embed fail, continue) | `TestErrorHandling` | 5 tests |
+| Row serialization integration (limit, batching) | `TestRowSerializationIntegration` | 4 tests |
+| Config interactions (clean names off, custom collection) | `TestConfigInteractions` | 2 tests |
+
+---
+
+## 7. Smoke Test
+
+**Status: PASS**
+
+```
+clean_name("First Name") == "first_name"  -- PASS
+clean_name("Revenue ($)") == "revenue"    -- PASS (parens and $ stripped, underscores collapsed+stripped)
+deduplicate_names(["a", "a", "b"]) == ["a", "a_1", "b"]  -- PASS
+Import from ingestkit_excel top-level  -- PASS
+SMOKE TEST PASSED
+```
+
+Note: `clean_name("Revenue ($)")` produces `"revenue"` (not `"revenue___"` as the spec speculated) because the regex replaces special chars with underscores, then collapses consecutive underscores, then strips leading/trailing underscores. This is correct behavior.
+
+---
+
+## Summary
+
+All 7 verification steps pass. Issue #8 (Path A Structured DB Processor) is correctly implemented with:
+
+- Clean module-level helpers (`clean_name`, `deduplicate_names`)
+- Full `StructuredDBProcessor` class with `process()` method
+- Correct ENUM_VALUE handling (string for metadata, enum member for result)
+- Comprehensive test coverage (50+ tests across 11 test classes)
+- Proper package exports at both processor and top-level
+- Smoke test confirms imports and basic behavior

--- a/packages/ingestkit-excel/src/ingestkit_excel/__init__.py
+++ b/packages/ingestkit-excel/src/ingestkit_excel/__init__.py
@@ -30,6 +30,7 @@ from ingestkit_excel.models import (
 from ingestkit_excel.inspector import ExcelInspector
 from ingestkit_excel.llm_classifier import LLMClassifier
 from ingestkit_excel.parser_chain import ParserChain
+from ingestkit_excel.processors import StructuredDBProcessor
 from ingestkit_excel.protocols import (
     EmbeddingBackend,
     LLMBackend,
@@ -66,6 +67,8 @@ __all__ = [
     "ExcelInspector",
     # LLM Classifier
     "LLMClassifier",
+    # Processors
+    "StructuredDBProcessor",
     # Errors
     "ErrorCode",
     "IngestError",

--- a/packages/ingestkit-excel/src/ingestkit_excel/processors/__init__.py
+++ b/packages/ingestkit-excel/src/ingestkit_excel/processors/__init__.py
@@ -1,0 +1,5 @@
+"""Processing-path implementations for ingestkit-excel."""
+
+from ingestkit_excel.processors.structured_db import StructuredDBProcessor
+
+__all__ = ["StructuredDBProcessor"]

--- a/packages/ingestkit-excel/src/ingestkit_excel/processors/structured_db.py
+++ b/packages/ingestkit-excel/src/ingestkit_excel/processors/structured_db.py
@@ -1,0 +1,558 @@
+"""Path A processor: structured DB ingestion with optional row serialization."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import time
+import uuid
+from pathlib import Path
+
+import pandas as pd
+
+from ingestkit_excel.config import ExcelProcessorConfig
+from ingestkit_excel.errors import ErrorCode, IngestError
+from ingestkit_excel.models import (
+    ChunkMetadata,
+    ChunkPayload,
+    ClassificationResult,
+    ClassificationStageResult,
+    EmbedStageResult,
+    FileProfile,
+    IngestionMethod,
+    ParseStageResult,
+    ProcessingResult,
+    SheetProfile,
+    WrittenArtifacts,
+)
+from ingestkit_excel.protocols import (
+    EmbeddingBackend,
+    StructuredDBBackend,
+    VectorStoreBackend,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def clean_name(raw: str) -> str:
+    """Clean a raw name (column or sheet) for use as a DB identifier.
+
+    Rules:
+    1. Lowercase
+    2. Replace non-alphanumeric/underscore with underscore
+    3. Collapse consecutive underscores
+    4. Strip leading/trailing underscores
+    """
+    name = raw.lower()
+    name = re.sub(r"[^a-z0-9_]", "_", name)
+    name = re.sub(r"_+", "_", name)
+    name = name.strip("_")
+    return name
+
+
+def deduplicate_names(names: list[str]) -> list[str]:
+    """Deduplicate a list of cleaned names by appending _1, _2, etc.
+
+    Empty names after cleaning become ``column_N`` where N is the 0-based index.
+    """
+    seen: dict[str, int] = {}
+    result: list[str] = []
+    for i, name in enumerate(names):
+        if not name:
+            name = f"column_{i}"
+        if name in seen:
+            seen[name] += 1
+            result.append(f"{name}_{seen[name]}")
+        else:
+            seen[name] = 0
+            result.append(name)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Processor
+# ---------------------------------------------------------------------------
+
+
+class StructuredDBProcessor:
+    """Path A processor: writes each sheet to a structured DB table,
+    generates NL schema descriptions, embeds them, and optionally
+    serializes rows for direct vector search.
+    """
+
+    def __init__(
+        self,
+        structured_db: StructuredDBBackend,
+        vector_store: VectorStoreBackend,
+        embedder: EmbeddingBackend,
+        config: ExcelProcessorConfig,
+    ) -> None:
+        self._db = structured_db
+        self._vector_store = vector_store
+        self._embedder = embedder
+        self._config = config
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def process(
+        self,
+        file_path: str,
+        profile: FileProfile,
+        ingest_key: str,
+        ingest_run_id: str,
+        parse_result: ParseStageResult,
+        classification_result: ClassificationStageResult,
+        classification: ClassificationResult,
+    ) -> ProcessingResult:
+        """Process an Excel file via Path A (structured DB ingestion).
+
+        Args:
+            file_path: Absolute path to the Excel file on disk.
+            profile: Pre-computed structural profile of the file.
+            ingest_key: Deterministic SHA-256 hex string from ``IngestKey.key``.
+            ingest_run_id: UUID4 string unique to this processing run.
+            parse_result: Typed output of the parsing stage.
+            classification_result: Typed output of the classification stage.
+            classification: Simplified classification result.
+
+        Returns:
+            A fully-assembled ``ProcessingResult``.
+        """
+        start_time = time.monotonic()
+
+        config = self._config
+        collection = config.default_collection
+        source_uri = f"file://{Path(file_path).resolve().as_posix()}"
+        db_uri = self._db.get_connection_uri()
+
+        errors: list[str] = []
+        warnings: list[str] = []
+        error_details: list[IngestError] = []
+
+        written = WrittenArtifacts(vector_collection=collection)
+        tables: list[str] = []
+        total_chunks = 0
+        total_texts_embedded = 0
+        embed_duration = 0.0
+
+        # Ensure vector collection exists
+        vector_size = self._embedder.dimension()
+        self._vector_store.ensure_collection(collection, vector_size)
+
+        chunk_index_counter = 0  # global chunk index across all sheets
+
+        for sheet in profile.sheets:
+            # --- Skip logic ---
+            if sheet.is_hidden:
+                warnings.append(ErrorCode.W_SHEET_SKIPPED_HIDDEN.value)
+                logger.info("Skipping hidden sheet: %s", sheet.name)
+                continue
+            if sheet.row_count == 0 and sheet.col_count == 0:
+                # chart-only heuristic
+                warnings.append(ErrorCode.W_SHEET_SKIPPED_CHART.value)
+                logger.info("Skipping chart-only sheet: %s", sheet.name)
+                continue
+            if sheet.row_count > config.max_rows_in_memory:
+                warnings.append(ErrorCode.W_ROWS_TRUNCATED.value)
+                logger.warning(
+                    "Sheet %s has %d rows, exceeds max_rows_in_memory (%d), skipping",
+                    sheet.name,
+                    sheet.row_count,
+                    config.max_rows_in_memory,
+                )
+                continue
+
+            try:
+                # --- Step 1: Load DataFrame ---
+                header_arg = sheet.header_row_index if sheet.header_row_detected else None
+                df = pd.read_excel(
+                    file_path,
+                    sheet_name=sheet.name,
+                    header=header_arg,
+                )
+
+                # --- Step 2: Clean column names ---
+                if config.clean_column_names:
+                    cleaned = [clean_name(str(c)) for c in df.columns]
+                    cleaned = deduplicate_names(cleaned)
+                    df.columns = cleaned
+
+                # --- Step 3: Auto-detect dates ---
+                df = self._auto_detect_dates(df)
+
+                # --- Step 4: Write to DB ---
+                table_name = clean_name(sheet.name)
+                if not table_name:
+                    table_name = f"sheet_{profile.sheets.index(sheet)}"
+                # Deduplicate table names across sheets
+                if table_name in tables:
+                    suffix = 1
+                    while f"{table_name}_{suffix}" in tables:
+                        suffix += 1
+                    table_name = f"{table_name}_{suffix}"
+
+                self._db.create_table_from_dataframe(table_name, df)
+                written.db_table_names.append(table_name)
+                tables.append(table_name)
+
+                # --- Step 5: Generate schema description ---
+                schema_text = self._generate_schema_description(table_name, df)
+
+                # --- Step 6: Embed schema + upsert ---
+                embed_start = time.monotonic()
+                vectors = self._embedder.embed(
+                    [schema_text],
+                    timeout=config.backend_timeout_seconds,
+                )
+                embed_duration += time.monotonic() - embed_start
+                total_texts_embedded += 1
+
+                chunk_hash = hashlib.sha256(schema_text.encode()).hexdigest()
+                chunk_id = str(
+                    uuid.uuid5(
+                        uuid.NAMESPACE_URL,
+                        f"{ingest_key}:{chunk_hash}",
+                    )
+                )
+                columns_list = list(df.columns)
+
+                metadata = ChunkMetadata(
+                    source_uri=source_uri,
+                    source_format="xlsx",
+                    sheet_name=sheet.name,
+                    region_id=None,
+                    ingestion_method=IngestionMethod.SQL_AGENT.value,  # "sql_agent"
+                    parser_used=sheet.parser_used.value,  # "openpyxl"
+                    parser_version=config.parser_version,
+                    chunk_index=chunk_index_counter,
+                    chunk_hash=chunk_hash,
+                    ingest_key=ingest_key,
+                    ingest_run_id=ingest_run_id,
+                    tenant_id=config.tenant_id,
+                    table_name=table_name,
+                    db_uri=db_uri,
+                    row_count=len(df),
+                    columns=columns_list,
+                )
+                chunk = ChunkPayload(
+                    id=chunk_id,
+                    text=schema_text,
+                    vector=vectors[0],
+                    metadata=metadata,
+                )
+
+                self._vector_store.upsert_chunks(collection, [chunk])
+                written.vector_point_ids.append(chunk_id)
+                chunk_index_counter += 1
+                total_chunks += 1
+
+                # --- Step 7: Optional row serialization ---
+                if len(df) < config.row_serialization_limit:
+                    row_chunks = self._serialize_rows(
+                        table_name=table_name,
+                        df=df,
+                        start_chunk_index=chunk_index_counter,
+                        sheet=sheet,
+                        source_uri=source_uri,
+                        db_uri=db_uri,
+                        ingest_key=ingest_key,
+                        ingest_run_id=ingest_run_id,
+                    )
+                    # Embed in batches
+                    for batch_start in range(
+                        0, len(row_chunks), config.embedding_batch_size
+                    ):
+                        batch = row_chunks[
+                            batch_start : batch_start + config.embedding_batch_size
+                        ]
+                        texts = [c.text for c in batch]
+                        embed_start = time.monotonic()
+                        vectors = self._embedder.embed(
+                            texts,
+                            timeout=config.backend_timeout_seconds,
+                        )
+                        embed_duration += time.monotonic() - embed_start
+                        total_texts_embedded += len(texts)
+                        for c, vec in zip(batch, vectors):
+                            c.vector = vec
+
+                        self._vector_store.upsert_chunks(collection, list(batch))
+                        for c in batch:
+                            written.vector_point_ids.append(c.id)
+                        total_chunks += len(batch)
+
+                    chunk_index_counter += len(row_chunks)
+
+            except Exception as exc:
+                # Per-sheet error handling: log, record, continue to next sheet
+                error_code = self._classify_backend_error(exc)
+                errors.append(error_code.value)
+                error_details.append(
+                    IngestError(
+                        code=error_code,
+                        message=str(exc),
+                        sheet_name=sheet.name,
+                        stage="process",
+                        recoverable=False,
+                    )
+                )
+                logger.exception(
+                    "Error processing sheet %s: %s", sheet.name, exc
+                )
+                continue
+
+        # --- Assemble EmbedStageResult ---
+        embed_result = None
+        if total_texts_embedded > 0:
+            embed_result = EmbedStageResult(
+                texts_embedded=total_texts_embedded,
+                embedding_dimension=self._embedder.dimension(),
+                embed_duration_seconds=embed_duration,
+            )
+
+        elapsed = time.monotonic() - start_time
+
+        return ProcessingResult(
+            file_path=file_path,
+            ingest_key=ingest_key,
+            ingest_run_id=ingest_run_id,
+            tenant_id=config.tenant_id,
+            parse_result=parse_result,
+            classification_result=classification_result,
+            embed_result=embed_result,
+            classification=classification,
+            ingestion_method=IngestionMethod.SQL_AGENT,  # enum member, NOT string
+            chunks_created=total_chunks,
+            tables_created=len(tables),
+            tables=tables,
+            written=written,
+            errors=errors,
+            warnings=warnings,
+            error_details=error_details,
+            processing_time_seconds=elapsed,
+        )
+
+    # ------------------------------------------------------------------
+    # Private methods
+    # ------------------------------------------------------------------
+
+    def _auto_detect_dates(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Auto-detect and convert date columns in-place.
+
+        Two heuristics:
+        1. Excel serial dates: numeric columns with values in 35000..55000 range
+        2. String dates: object columns where >50% of non-null values parse as dates
+        """
+        SERIAL_MIN = 35_000  # ~1995
+        SERIAL_MAX = 55_000  # ~2050
+        DATE_PARSE_THRESHOLD = 0.5
+
+        for col in df.columns:
+            series = df[col]
+            non_null = series.dropna()
+            if len(non_null) == 0:
+                continue
+
+            # Heuristic 1: Excel serial dates
+            if pd.api.types.is_numeric_dtype(series):
+                if (non_null >= SERIAL_MIN).all() and (non_null <= SERIAL_MAX).all():
+                    try:
+                        df[col] = pd.to_datetime(
+                            series,
+                            origin="1899-12-30",
+                            unit="D",
+                            errors="coerce",
+                        )
+                        logger.debug(
+                            "Converted column '%s' from Excel serial date", col
+                        )
+                    except Exception:
+                        pass  # leave as-is if conversion fails
+                continue
+
+            # Heuristic 2: String dates (object or string dtype)
+            if series.dtype == object or pd.api.types.is_string_dtype(series):
+                try:
+                    parsed = pd.to_datetime(non_null, format="mixed", errors="coerce")
+                    success_ratio = parsed.notna().sum() / len(non_null)
+                    if success_ratio >= DATE_PARSE_THRESHOLD:
+                        df[col] = pd.to_datetime(
+                            series,
+                            format="mixed",
+                            errors="coerce",
+                        )
+                        logger.debug(
+                            "Converted column '%s' from string dates (%.0f%% parsed)",
+                            col,
+                            success_ratio * 100,
+                        )
+                except Exception:
+                    pass  # leave as-is
+
+        return df
+
+    def _generate_schema_description(
+        self, table_name: str, df: pd.DataFrame
+    ) -> str:
+        """Generate a natural language schema description for embedding.
+
+        Format:
+            Table "{table_name}" contains {N} rows with columns:
+            - col_name (type): description
+            ...
+        """
+        LOW_CARDINALITY_THRESHOLD = 20
+        lines = [f'Table "{table_name}" contains {len(df)} rows with columns:']
+
+        for col in df.columns:
+            series = df[col].dropna()
+            col_type = self._infer_type_label(df[col])
+            desc = self._describe_column(series, col_type, LOW_CARDINALITY_THRESHOLD)
+            lines.append(f"- {col} ({col_type}): {desc}")
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _infer_type_label(series: pd.Series) -> str:
+        """Map a pandas dtype to a human-readable type label."""
+        dtype = series.dtype
+        if pd.api.types.is_integer_dtype(dtype):
+            return "integer"
+        if pd.api.types.is_float_dtype(dtype):
+            return "float"
+        if pd.api.types.is_bool_dtype(dtype):
+            return "boolean"
+        if pd.api.types.is_datetime64_any_dtype(dtype):
+            return "date"
+        return "text"
+
+    @staticmethod
+    def _describe_column(
+        series: pd.Series,
+        col_type: str,
+        low_card_threshold: int,
+    ) -> str:
+        """Generate a human-readable description of a column's values."""
+        if len(series) == 0:
+            return "no data"
+
+        if col_type in ("integer", "float"):
+            return f"range {series.min()} to {series.max()}"
+
+        if col_type == "date":
+            return f"ranges from {series.min()} to {series.max()}"
+
+        if col_type == "boolean":
+            return "true/false"
+
+        # text
+        n_unique = series.nunique()
+        if n_unique < low_card_threshold:
+            unique_vals = ", ".join(
+                str(v) for v in series.unique()[:low_card_threshold]
+            )
+            return f"one of {unique_vals}"
+        return f"{n_unique} unique values"
+
+    def _serialize_rows(
+        self,
+        table_name: str,
+        df: pd.DataFrame,
+        start_chunk_index: int,
+        sheet: SheetProfile,
+        source_uri: str,
+        db_uri: str,
+        ingest_key: str,
+        ingest_run_id: str,
+    ) -> list[ChunkPayload]:
+        """Serialize each row into a natural language sentence.
+
+        Returns ChunkPayload objects with vectors set to empty lists.
+        Vectors are populated later during batch embedding.
+
+        Format: "In table '{table_name}', row {N}: {col} is {val}, ..."
+        """
+        config = self._config
+        columns_list = list(df.columns)
+        chunks: list[ChunkPayload] = []
+
+        for row_idx, row in df.iterrows():
+            # Build row text
+            parts = []
+            for col in df.columns:
+                val = row[col]
+                if pd.isna(val):
+                    parts.append(f"{col} is N/A")
+                else:
+                    parts.append(f"{col} is {val}")
+            row_number = row_idx + 1 if isinstance(row_idx, int) else row_idx
+            text = f"In table '{table_name}', row {row_number}: {', '.join(parts)}."
+
+            chunk_hash = hashlib.sha256(text.encode()).hexdigest()
+            chunk_id = str(
+                uuid.uuid5(
+                    uuid.NAMESPACE_URL,
+                    f"{ingest_key}:{chunk_hash}",
+                )
+            )
+            chunk_index = start_chunk_index + len(chunks)
+
+            metadata = ChunkMetadata(
+                source_uri=source_uri,
+                source_format="xlsx",
+                sheet_name=sheet.name,
+                region_id=None,
+                ingestion_method=IngestionMethod.SQL_AGENT.value,  # "sql_agent"
+                parser_used=sheet.parser_used.value,
+                parser_version=config.parser_version,
+                chunk_index=chunk_index,
+                chunk_hash=chunk_hash,
+                ingest_key=ingest_key,
+                ingest_run_id=ingest_run_id,
+                tenant_id=config.tenant_id,
+                table_name=table_name,
+                db_uri=db_uri,
+                row_count=len(df),
+                columns=columns_list,
+            )
+            chunks.append(
+                ChunkPayload(
+                    id=chunk_id,
+                    text=text,
+                    vector=[],  # placeholder; populated during batch embedding
+                    metadata=metadata,
+                )
+            )
+
+        return chunks
+
+    @staticmethod
+    def _classify_backend_error(exc: Exception) -> ErrorCode:
+        """Map an exception to the most appropriate ErrorCode.
+
+        Inspects exception type and message to differentiate timeout vs
+        connection errors for each backend type.
+        """
+        msg = str(exc).lower()
+        if "timeout" in msg or "timed out" in msg:
+            if "embed" in msg:
+                return ErrorCode.E_BACKEND_EMBED_TIMEOUT
+            if "vector" in msg or "qdrant" in msg or "collection" in msg:
+                return ErrorCode.E_BACKEND_VECTOR_TIMEOUT
+            return ErrorCode.E_BACKEND_DB_TIMEOUT
+        if "connect" in msg or "connection" in msg:
+            if "embed" in msg:
+                return ErrorCode.E_BACKEND_EMBED_CONNECT
+            if "vector" in msg or "qdrant" in msg or "collection" in msg:
+                return ErrorCode.E_BACKEND_VECTOR_CONNECT
+            return ErrorCode.E_BACKEND_DB_CONNECT
+        # Default to schema gen error for unknown exceptions during processing
+        return ErrorCode.E_PROCESS_SCHEMA_GEN

--- a/packages/ingestkit-excel/tests/test_structured_db.py
+++ b/packages/ingestkit-excel/tests/test_structured_db.py
@@ -1,0 +1,1458 @@
+"""Tests for the StructuredDBProcessor (Path A).
+
+Covers column cleaning, date detection, schema description generation,
+row serialization, full process flow, multi-sheet processing, error
+handling, and WrittenArtifacts tracking.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from ingestkit_excel.config import ExcelProcessorConfig
+from ingestkit_excel.errors import ErrorCode, IngestError
+from ingestkit_excel.models import (
+    ChunkMetadata,
+    ChunkPayload,
+    ClassificationResult,
+    ClassificationStageResult,
+    ClassificationTier,
+    EmbedStageResult,
+    FileProfile,
+    FileType,
+    IngestionMethod,
+    ParseStageResult,
+    ParserUsed,
+    ProcessingResult,
+    SheetProfile,
+    WrittenArtifacts,
+)
+from ingestkit_excel.processors.structured_db import (
+    StructuredDBProcessor,
+    clean_name,
+    deduplicate_names,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test Helper Factories
+# ---------------------------------------------------------------------------
+
+
+def _make_sheet_profile(**overrides: object) -> SheetProfile:
+    """Build a SheetProfile with sensible tabular defaults."""
+    defaults: dict = dict(
+        name="Sheet1",
+        row_count=100,
+        col_count=5,
+        merged_cell_count=0,
+        merged_cell_ratio=0.0,
+        header_row_detected=True,
+        header_row_index=0,
+        header_values=["A", "B", "C", "D", "E"],
+        column_type_consistency=0.9,
+        numeric_ratio=0.4,
+        text_ratio=0.5,
+        empty_ratio=0.1,
+        sample_rows=[["1", "a", "x", "2.0", "y"]],
+        has_formulas=False,
+        is_hidden=False,
+        parser_used=ParserUsed.OPENPYXL,
+    )
+    defaults.update(overrides)
+    return SheetProfile(**defaults)
+
+
+def _make_file_profile(
+    sheets: list[SheetProfile],
+    **overrides: object,
+) -> FileProfile:
+    """Build a FileProfile from a list of SheetProfiles."""
+    defaults: dict = dict(
+        file_path="/tmp/test.xlsx",
+        file_size_bytes=1024,
+        sheet_count=len(sheets),
+        sheet_names=[s.name for s in sheets],
+        sheets=sheets,
+        has_password_protected_sheets=False,
+        has_chart_only_sheets=False,
+        total_merged_cells=sum(s.merged_cell_count for s in sheets),
+        total_rows=sum(s.row_count for s in sheets),
+        content_hash="a" * 64,
+    )
+    defaults.update(overrides)
+    return FileProfile(**defaults)
+
+
+def _make_parse_result(**overrides: object) -> ParseStageResult:
+    defaults: dict = dict(
+        parser_used=ParserUsed.OPENPYXL,
+        fallback_reason_code=None,
+        sheets_parsed=1,
+        sheets_skipped=0,
+        skipped_reasons={},
+        parse_duration_seconds=0.1,
+    )
+    defaults.update(overrides)
+    return ParseStageResult(**defaults)
+
+
+def _make_classification_stage_result(**overrides: object) -> ClassificationStageResult:
+    defaults: dict = dict(
+        tier_used=ClassificationTier.RULE_BASED,
+        file_type=FileType.TABULAR_DATA,
+        confidence=0.95,
+        signals=None,
+        reasoning="High column consistency, low merged cells",
+        per_sheet_types=None,
+        classification_duration_seconds=0.05,
+    )
+    defaults.update(overrides)
+    return ClassificationStageResult(**defaults)
+
+
+def _make_classification_result(**overrides: object) -> ClassificationResult:
+    defaults: dict = dict(
+        file_type=FileType.TABULAR_DATA,
+        confidence=0.95,
+        tier_used=ClassificationTier.RULE_BASED,
+        reasoning="High column consistency, low merged cells",
+        per_sheet_types=None,
+        signals=None,
+    )
+    defaults.update(overrides)
+    return ClassificationResult(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Mock Backends
+# ---------------------------------------------------------------------------
+
+
+class MockStructuredDB:
+    """Mock StructuredDBBackend for testing."""
+
+    def __init__(self, connection_uri: str = "sqlite:///test.db"):
+        self._uri = connection_uri
+        self.tables_created: list[tuple[str, pd.DataFrame]] = []
+        self.fail_on: str | None = None  # table name to fail on
+
+    def create_table_from_dataframe(self, table_name: str, df: pd.DataFrame) -> None:
+        if self.fail_on and table_name == self.fail_on:
+            raise RuntimeError(f"DB connection error for table {table_name}")
+        self.tables_created.append((table_name, df.copy()))
+
+    def drop_table(self, table_name: str) -> None:
+        pass
+
+    def table_exists(self, table_name: str) -> bool:
+        return any(t[0] == table_name for t in self.tables_created)
+
+    def get_table_schema(self, table_name: str) -> dict:
+        return {}
+
+    def get_connection_uri(self) -> str:
+        return self._uri
+
+
+class MockVectorStore:
+    """Mock VectorStoreBackend for testing."""
+
+    def __init__(self):
+        self.collections_ensured: list[tuple[str, int]] = []
+        self.upserted: list[tuple[str, list[ChunkPayload]]] = []
+        self.fail_on_upsert: bool = False
+
+    def upsert_chunks(self, collection: str, chunks: list[ChunkPayload]) -> int:
+        if self.fail_on_upsert:
+            raise RuntimeError("Vector store connection error")
+        self.upserted.append((collection, chunks))
+        return len(chunks)
+
+    def ensure_collection(self, collection: str, vector_size: int) -> None:
+        self.collections_ensured.append((collection, vector_size))
+
+    def create_payload_index(
+        self, collection: str, field: str, field_type: str
+    ) -> None:
+        pass
+
+    def delete_by_ids(self, collection: str, ids: list[str]) -> int:
+        return len(ids)
+
+
+class MockEmbedder:
+    """Mock EmbeddingBackend for testing."""
+
+    def __init__(self, dim: int = 768):
+        self._dim = dim
+        self.embed_calls: list[list[str]] = []
+        self.fail_on_embed: bool = False
+
+    def embed(
+        self, texts: list[str], timeout: float | None = None
+    ) -> list[list[float]]:
+        if self.fail_on_embed:
+            raise RuntimeError("Embedding timeout error")
+        self.embed_calls.append(texts)
+        return [[0.1] * self._dim for _ in texts]
+
+    def dimension(self) -> int:
+        return self._dim
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_db() -> MockStructuredDB:
+    return MockStructuredDB()
+
+
+@pytest.fixture()
+def mock_vector_store() -> MockVectorStore:
+    return MockVectorStore()
+
+
+@pytest.fixture()
+def mock_embedder() -> MockEmbedder:
+    return MockEmbedder()
+
+
+@pytest.fixture()
+def config() -> ExcelProcessorConfig:
+    return ExcelProcessorConfig()
+
+
+@pytest.fixture()
+def processor(
+    mock_db: MockStructuredDB,
+    mock_vector_store: MockVectorStore,
+    mock_embedder: MockEmbedder,
+    config: ExcelProcessorConfig,
+) -> StructuredDBProcessor:
+    return StructuredDBProcessor(mock_db, mock_vector_store, mock_embedder, config)
+
+
+# ---------------------------------------------------------------------------
+# Section: Column Name Cleaning (clean_name and deduplicate_names)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanName:
+    """Tests for the clean_name helper."""
+
+    def test_clean_name_lowercase(self):
+        assert clean_name("Hello World") == "hello_world"
+
+    def test_clean_name_special_chars(self):
+        assert clean_name("Col #1 (USD)") == "col_1_usd"
+
+    def test_clean_name_consecutive_underscores(self):
+        assert clean_name("a___b") == "a_b"
+
+    def test_clean_name_leading_trailing_underscores(self):
+        assert clean_name("__name__") == "name"
+
+    def test_clean_name_empty_string(self):
+        assert clean_name("") == ""
+
+    def test_clean_name_unicode(self):
+        # Umlaut characters get replaced with underscores
+        result = clean_name("Geb\u00fchrenstatus")
+        assert "_" in result or result.isascii()
+        # The umlaut 'u' should be replaced
+        assert "geb" in result
+
+    def test_clean_name_numeric_only(self):
+        assert clean_name("123") == "123"
+
+
+class TestDeduplicateNames:
+    """Tests for the deduplicate_names helper."""
+
+    def test_deduplicate_names_no_dupes(self):
+        assert deduplicate_names(["a", "b", "c"]) == ["a", "b", "c"]
+
+    def test_deduplicate_names_with_dupes(self):
+        assert deduplicate_names(["a", "a", "a"]) == ["a", "a_1", "a_2"]
+
+    def test_deduplicate_names_empty_becomes_column_n(self):
+        assert deduplicate_names(["", "", "a"]) == ["column_0", "column_1", "a"]
+
+    def test_deduplicate_names_mixed(self):
+        assert deduplicate_names(["id", "", "id", "name"]) == [
+            "id",
+            "column_1",
+            "id_1",
+            "name",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Section: Date Detection (_auto_detect_dates)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoDetectDates:
+    """Tests for the _auto_detect_dates private method."""
+
+    def test_auto_detect_excel_serial_dates(self, processor):
+        df = pd.DataFrame({"date_col": [44197, 44228, 44256]})  # ~2021 dates
+        result = processor._auto_detect_dates(df)
+        assert pd.api.types.is_datetime64_any_dtype(result["date_col"])
+
+    def test_auto_detect_string_dates(self, processor):
+        df = pd.DataFrame(
+            {"date_col": ["2023-01-15", "2023-02-20", "2023-03-10"]}
+        )
+        result = processor._auto_detect_dates(df)
+        assert pd.api.types.is_datetime64_any_dtype(result["date_col"])
+
+    def test_auto_detect_skips_integers_outside_range(self, processor):
+        df = pd.DataFrame({"ids": [1, 2, 3, 50, 100]})
+        result = processor._auto_detect_dates(df)
+        assert pd.api.types.is_integer_dtype(result["ids"])
+
+    def test_auto_detect_mixed_dates_below_threshold(self, processor):
+        # Less than 50% parse as dates -> should NOT convert
+        df = pd.DataFrame(
+            {"mixed": ["2023-01-15", "not_a_date", "also_not", "nope"]}
+        )
+        result = processor._auto_detect_dates(df)
+        assert not pd.api.types.is_datetime64_any_dtype(result["mixed"])
+
+    def test_auto_detect_empty_column_ignored(self, processor):
+        df = pd.DataFrame({"empty": [None, None, None]})
+        result = processor._auto_detect_dates(df)
+        # Should not raise and column should remain as-is
+        assert len(result) == 3
+
+    def test_auto_detect_preserves_non_date_columns(self, processor):
+        df = pd.DataFrame(
+            {
+                "ids": [1, 2, 3],
+                "names": ["Alice", "Bob", "Carol"],
+                "serial_dates": [44197, 44228, 44256],
+            }
+        )
+        result = processor._auto_detect_dates(df)
+        assert pd.api.types.is_integer_dtype(result["ids"])
+        assert not pd.api.types.is_datetime64_any_dtype(result["names"])
+        assert pd.api.types.is_datetime64_any_dtype(result["serial_dates"])
+
+
+# ---------------------------------------------------------------------------
+# Section: Schema Description Generation
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaDescription:
+    """Tests for the _generate_schema_description method."""
+
+    def test_schema_description_contains_table_name(self, processor):
+        df = pd.DataFrame({"a": [1, 2, 3]})
+        text = processor._generate_schema_description("my_table", df)
+        assert 'Table "my_table"' in text
+
+    def test_schema_description_integer_column_range(self, processor):
+        df = pd.DataFrame({"count": [10, 20, 30]})
+        text = processor._generate_schema_description("t", df)
+        assert "range 10 to 30" in text
+
+    def test_schema_description_float_column_range(self, processor):
+        df = pd.DataFrame({"price": [1.5, 2.5, 3.5]})
+        text = processor._generate_schema_description("t", df)
+        assert "range 1.5 to 3.5" in text
+
+    def test_schema_description_text_low_cardinality(self, processor):
+        df = pd.DataFrame({"dept": ["HR", "Sales", "Eng"]})
+        text = processor._generate_schema_description("t", df)
+        assert "one of" in text
+        assert "HR" in text
+        assert "Sales" in text
+
+    def test_schema_description_text_high_cardinality(self, processor):
+        df = pd.DataFrame({"names": [f"name_{i}" for i in range(25)]})
+        text = processor._generate_schema_description("t", df)
+        assert "25 unique values" in text
+
+    def test_schema_description_date_column_range(self, processor):
+        df = pd.DataFrame(
+            {"date": pd.to_datetime(["2023-01-01", "2023-06-15", "2023-12-31"])}
+        )
+        text = processor._generate_schema_description("t", df)
+        assert "ranges from" in text
+
+    def test_schema_description_boolean_column(self, processor):
+        df = pd.DataFrame({"active": [True, False, True]})
+        text = processor._generate_schema_description("t", df)
+        assert "true/false" in text
+
+    def test_schema_description_row_count(self, processor):
+        df = pd.DataFrame({"a": [1, 2, 3, 4, 5]})
+        text = processor._generate_schema_description("t", df)
+        assert "contains 5 rows" in text
+
+
+# ---------------------------------------------------------------------------
+# Section: Row Serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeRows:
+    """Tests for the _serialize_rows private method."""
+
+    def test_serialize_rows_format(self, processor):
+        df = pd.DataFrame({"id": [1, 2], "name": ["Alice", "Bob"]})
+        sheet = _make_sheet_profile(name="Sheet1")
+        chunks = processor._serialize_rows(
+            table_name="employees",
+            df=df,
+            start_chunk_index=1,
+            sheet=sheet,
+            source_uri="file:///tmp/test.xlsx",
+            db_uri="sqlite:///test.db",
+            ingest_key="abc123",
+            ingest_run_id="run-1",
+        )
+        assert len(chunks) == 2
+        assert "In table 'employees', row 1:" in chunks[0].text
+        assert "id is 1" in chunks[0].text
+        assert "name is Alice" in chunks[0].text
+
+    def test_serialize_rows_handles_nan(self, processor):
+        df = pd.DataFrame({"id": [1], "name": [None]})
+        sheet = _make_sheet_profile(name="Sheet1")
+        chunks = processor._serialize_rows(
+            table_name="t",
+            df=df,
+            start_chunk_index=0,
+            sheet=sheet,
+            source_uri="file:///tmp/test.xlsx",
+            db_uri="sqlite:///test.db",
+            ingest_key="key",
+            ingest_run_id="run",
+        )
+        assert "name is N/A" in chunks[0].text
+
+    def test_serialize_rows_chunk_metadata_correct(self, processor):
+        df = pd.DataFrame({"id": [1]})
+        sheet = _make_sheet_profile(name="MySheet")
+        chunks = processor._serialize_rows(
+            table_name="my_table",
+            df=df,
+            start_chunk_index=5,
+            sheet=sheet,
+            source_uri="file:///tmp/test.xlsx",
+            db_uri="sqlite:///test.db",
+            ingest_key="key",
+            ingest_run_id="run",
+        )
+        meta = chunks[0].metadata
+        assert meta.table_name == "my_table"
+        assert meta.chunk_index == 5
+        assert meta.sheet_name == "MySheet"
+
+    def test_serialize_rows_chunk_ids_deterministic(self, processor):
+        df = pd.DataFrame({"id": [1]})
+        sheet = _make_sheet_profile(name="Sheet1")
+        kwargs = dict(
+            table_name="t",
+            df=df,
+            start_chunk_index=0,
+            sheet=sheet,
+            source_uri="file:///tmp/test.xlsx",
+            db_uri="sqlite:///test.db",
+            ingest_key="same_key",
+            ingest_run_id="run",
+        )
+        chunks1 = processor._serialize_rows(**kwargs)
+        chunks2 = processor._serialize_rows(**kwargs)
+        assert chunks1[0].id == chunks2[0].id
+
+    def test_serialize_rows_chunk_index_continues(self, processor):
+        df = pd.DataFrame({"id": [1, 2, 3]})
+        sheet = _make_sheet_profile(name="Sheet1")
+        chunks = processor._serialize_rows(
+            table_name="t",
+            df=df,
+            start_chunk_index=10,
+            sheet=sheet,
+            source_uri="file:///tmp/test.xlsx",
+            db_uri="sqlite:///test.db",
+            ingest_key="key",
+            ingest_run_id="run",
+        )
+        assert chunks[0].metadata.chunk_index == 10
+        assert chunks[1].metadata.chunk_index == 11
+        assert chunks[2].metadata.chunk_index == 12
+
+
+# ---------------------------------------------------------------------------
+# Section: Full Process Flow (with pd.read_excel mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessFlow:
+    """Tests for the full process() method with mocked pd.read_excel."""
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_single_sheet_happy_path(
+        self,
+        mock_read_excel,
+        processor,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        df = pd.DataFrame({"id": [1, 2, 3], "name": ["Alice", "Bob", "Carol"]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="Employees", row_count=3, col_count=2)
+        profile = _make_file_profile([sheet])
+        parse_result = _make_parse_result()
+        classification_stage = _make_classification_stage_result()
+        classification = _make_classification_result()
+
+        result = processor.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="abc123" * 10 + "abcd",
+            ingest_run_id="550e8400-e29b-41d4-a716-446655440000",
+            parse_result=parse_result,
+            classification_result=classification_stage,
+            classification=classification,
+        )
+
+        # Verify DB interaction
+        assert len(mock_db.tables_created) == 1
+        assert mock_db.tables_created[0][0] == "employees"
+
+        # Verify vector store interaction
+        assert len(mock_vector_store.upserted) >= 1
+        assert mock_vector_store.collections_ensured[0] == ("helpdesk", 768)
+
+        # Verify result structure
+        assert result.ingestion_method == IngestionMethod.SQL_AGENT
+        assert result.tables_created == 1
+        assert result.tables == ["employees"]
+        assert result.written.db_table_names == ["employees"]
+        assert len(result.written.vector_point_ids) >= 1
+        assert result.written.vector_collection == "helpdesk"
+        assert result.errors == []
+        assert result.processing_time_seconds > 0
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_result_ingestion_method(
+        self,
+        mock_read_excel,
+        processor,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        result = processor.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+        # Must be the enum member, NOT the string
+        assert result.ingestion_method == IngestionMethod.SQL_AGENT
+        assert result.ingestion_method is IngestionMethod.SQL_AGENT
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_chunk_metadata_ingestion_method(
+        self,
+        mock_read_excel,
+        processor,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        processor.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        chunk = mock_vector_store.upserted[0][1][0]
+        # ChunkMetadata.ingestion_method is a str field -> must be "sql_agent"
+        assert chunk.metadata.ingestion_method == "sql_agent"
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_chunk_metadata_parser_used(
+        self,
+        mock_read_excel,
+        processor,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(
+            name="S1", row_count=1, col_count=1, parser_used=ParserUsed.OPENPYXL
+        )
+        profile = _make_file_profile([sheet])
+
+        processor.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        chunk = mock_vector_store.upserted[0][1][0]
+        assert chunk.metadata.parser_used == "openpyxl"
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_written_artifacts_populated(
+        self,
+        mock_read_excel,
+        processor,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        result = processor.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert len(result.written.db_table_names) > 0
+        assert len(result.written.vector_point_ids) > 0
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_written_artifacts_collection(
+        self,
+        mock_read_excel,
+        processor,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        result = processor.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert result.written.vector_collection == "helpdesk"
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_source_uri_format(
+        self,
+        mock_read_excel,
+        processor,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        processor.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        chunk = mock_vector_store.upserted[0][1][0]
+        assert chunk.metadata.source_uri.startswith("file://")
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_db_uri_from_backend(
+        self,
+        mock_read_excel,
+        processor,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        processor.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        chunk = mock_vector_store.upserted[0][1][0]
+        assert chunk.metadata.db_uri == mock_db.get_connection_uri()
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_embed_result_populated(
+        self,
+        mock_read_excel,
+        processor,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        result = processor.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert result.embed_result is not None
+        assert result.embed_result.texts_embedded > 0
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_tables_created_count(
+        self,
+        mock_read_excel,
+        processor,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        result = processor.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert result.tables_created == 1
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_chunks_created_count_schema_only(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        """With row_serialization_limit=0, only schema chunk counted."""
+        cfg = ExcelProcessorConfig(row_serialization_limit=0)
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, cfg
+        )
+        df = pd.DataFrame({"a": [1, 2, 3]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=3, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        result = proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert result.chunks_created == 1  # schema only
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_tenant_id_passed_through(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        cfg = ExcelProcessorConfig(tenant_id="tenant_abc")
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, cfg
+        )
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        result = proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert result.tenant_id == "tenant_abc"
+        chunk = mock_vector_store.upserted[0][1][0]
+        assert chunk.metadata.tenant_id == "tenant_abc"
+
+
+# ---------------------------------------------------------------------------
+# Section: Row Serialization Integration (triggers / skips)
+# ---------------------------------------------------------------------------
+
+
+class TestRowSerializationIntegration:
+    """Tests for row serialization triggering/skipping during process()."""
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_row_serialization_below_limit(
+        self,
+        mock_read_excel,
+        processor,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        df = pd.DataFrame({"id": [1, 2, 3]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=3, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        result = processor.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        # 1 schema chunk + 3 row chunks = 4 total
+        assert result.chunks_created == 4
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_row_serialization_above_limit(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        cfg = ExcelProcessorConfig(row_serialization_limit=50)
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, cfg
+        )
+        df = pd.DataFrame({"id": list(range(100))})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=100, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        result = proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        # Only schema chunk, no row serialization
+        assert result.chunks_created == 1
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_row_serialization_batch_embedding(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        cfg = ExcelProcessorConfig(embedding_batch_size=64)
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, cfg
+        )
+        df = pd.DataFrame({"id": list(range(130))})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=130, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        # 1 schema embed call + 2 row batch embed calls (64 + 64 + 2) = 3 calls
+        # Actually: 1 schema + ceil(130/64) = 1 + 3 = 4 calls (64 + 64 + 2)
+        assert len(mock_embedder.embed_calls) == 4  # 1 schema + 3 row batches
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_row_serialization_batch_embedding_correct_batch_count(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        """130 rows with batch_size=64: ceil(130/64) = 3 row batches."""
+        cfg = ExcelProcessorConfig(embedding_batch_size=64)
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, cfg
+        )
+        df = pd.DataFrame({"id": list(range(130))})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=130, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        # First call: schema embed (1 text)
+        assert len(mock_embedder.embed_calls[0]) == 1
+        # Row batch calls
+        assert len(mock_embedder.embed_calls[1]) == 64
+        assert len(mock_embedder.embed_calls[2]) == 64
+        assert len(mock_embedder.embed_calls[3]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Section: Multi-Sheet Processing
+# ---------------------------------------------------------------------------
+
+
+class TestMultiSheetProcessing:
+    """Tests for multi-sheet processing flows."""
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_multi_sheet(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        cfg = ExcelProcessorConfig(row_serialization_limit=0)
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, cfg
+        )
+
+        df1 = pd.DataFrame({"id": [1, 2]})
+        df2 = pd.DataFrame({"name": ["A", "B"]})
+        mock_read_excel.side_effect = [df1, df2]
+
+        sheet1 = _make_sheet_profile(name="Sales", row_count=2, col_count=1)
+        sheet2 = _make_sheet_profile(name="Inventory", row_count=2, col_count=1)
+        profile = _make_file_profile([sheet1, sheet2])
+
+        result = proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert result.tables_created == 2
+        assert len(result.written.db_table_names) == 2
+        assert "sales" in result.tables
+        assert "inventory" in result.tables
+        assert result.chunks_created >= 2
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_multi_sheet_chunk_index_global(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        """chunk_index is global across sheets."""
+        cfg = ExcelProcessorConfig(row_serialization_limit=0)
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, cfg
+        )
+
+        df1 = pd.DataFrame({"id": [1]})
+        df2 = pd.DataFrame({"name": ["A"]})
+        mock_read_excel.side_effect = [df1, df2]
+
+        sheet1 = _make_sheet_profile(name="S1", row_count=1, col_count=1)
+        sheet2 = _make_sheet_profile(name="S2", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet1, sheet2])
+
+        proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        # First sheet schema chunk: index 0
+        chunk0 = mock_vector_store.upserted[0][1][0]
+        assert chunk0.metadata.chunk_index == 0
+        # Second sheet schema chunk: index 1
+        chunk1 = mock_vector_store.upserted[1][1][0]
+        assert chunk1.metadata.chunk_index == 1
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_duplicate_sheet_names_deduped(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        cfg = ExcelProcessorConfig(row_serialization_limit=0)
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, cfg
+        )
+
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet1 = _make_sheet_profile(name="Data", row_count=1, col_count=1)
+        sheet2 = _make_sheet_profile(name="Data", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet1, sheet2])
+
+        result = proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert "data" in result.tables
+        assert "data_1" in result.tables
+        assert result.tables_created == 2
+
+
+# ---------------------------------------------------------------------------
+# Section: Sheet Skipping
+# ---------------------------------------------------------------------------
+
+
+class TestSheetSkipping:
+    """Tests for sheet skipping logic."""
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_skips_hidden_sheet(
+        self,
+        mock_read_excel,
+        processor,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        sheet = _make_sheet_profile(name="Hidden", row_count=10, col_count=2, is_hidden=True)
+        profile = _make_file_profile([sheet])
+
+        result = processor.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert "W_SHEET_SKIPPED_HIDDEN" in result.warnings
+        assert result.tables_created == 0
+        mock_read_excel.assert_not_called()
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_skips_oversized_sheet(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        cfg = ExcelProcessorConfig(max_rows_in_memory=50)
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, cfg
+        )
+
+        sheet = _make_sheet_profile(name="Big", row_count=100, col_count=5)
+        profile = _make_file_profile([sheet])
+
+        result = proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert "W_ROWS_TRUNCATED" in result.warnings
+        assert result.tables_created == 0
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_all_sheets_skipped_empty_result(
+        self,
+        mock_read_excel,
+        processor,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        sheet = _make_sheet_profile(
+            name="Hidden", row_count=10, col_count=2, is_hidden=True
+        )
+        profile = _make_file_profile([sheet])
+
+        result = processor.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert result.tables_created == 0
+        assert result.chunks_created == 0
+        assert result.embed_result is None
+
+
+# ---------------------------------------------------------------------------
+# Section: Error Handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    """Tests for error handling during processing."""
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_db_failure_records_error(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+        config,
+    ):
+        mock_db.fail_on = "sheet1"
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, config
+        )
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="Sheet1", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        result = proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert len(result.errors) == 1
+        assert len(result.error_details) == 1
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_db_failure_continues_to_next_sheet(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+        config,
+    ):
+        mock_db.fail_on = "sheet1"
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, config
+        )
+
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet1 = _make_sheet_profile(name="Sheet1", row_count=1, col_count=1)
+        sheet2 = _make_sheet_profile(name="Sheet2", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet1, sheet2])
+
+        result = proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        # Sheet1 fails, Sheet2 succeeds
+        assert result.tables_created == 1
+        assert len(result.errors) == 1
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_embed_failure_records_error(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+        config,
+    ):
+        mock_embedder.fail_on_embed = True
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, config
+        )
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        result = proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert len(result.errors) == 1
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_error_details_stage_is_process(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+        config,
+    ):
+        mock_db.fail_on = "sheet1"
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, config
+        )
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="Sheet1", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        result = proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert result.error_details[0].stage == "process"
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_error_details_has_sheet_name(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+        config,
+    ):
+        mock_db.fail_on = "sheet1"
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, config
+        )
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="Sheet1", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        result = proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert result.error_details[0].sheet_name == "Sheet1"
+
+
+# ---------------------------------------------------------------------------
+# Section: Config Interactions
+# ---------------------------------------------------------------------------
+
+
+class TestConfigInteractions:
+    """Tests for config-driven behavior."""
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_clean_column_names_disabled(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        cfg = ExcelProcessorConfig(clean_column_names=False, row_serialization_limit=0)
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, cfg
+        )
+        df = pd.DataFrame({"My Column": [1, 2, 3]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=3, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        # Column names should NOT be cleaned
+        stored_df = mock_db.tables_created[0][1]
+        assert "My Column" in stored_df.columns
+
+    @patch("ingestkit_excel.processors.structured_db.pd.read_excel")
+    def test_process_custom_collection(
+        self,
+        mock_read_excel,
+        mock_db,
+        mock_vector_store,
+        mock_embedder,
+    ):
+        cfg = ExcelProcessorConfig(
+            default_collection="custom_collection", row_serialization_limit=0
+        )
+        proc = StructuredDBProcessor(
+            mock_db, mock_vector_store, mock_embedder, cfg
+        )
+        df = pd.DataFrame({"a": [1]})
+        mock_read_excel.return_value = df
+
+        sheet = _make_sheet_profile(name="S1", row_count=1, col_count=1)
+        profile = _make_file_profile([sheet])
+
+        result = proc.process(
+            file_path="/tmp/test.xlsx",
+            profile=profile,
+            ingest_key="k" * 64,
+            ingest_run_id="run-1",
+            parse_result=_make_parse_result(),
+            classification_result=_make_classification_stage_result(),
+            classification=_make_classification_result(),
+        )
+
+        assert mock_vector_store.collections_ensured[0][0] == "custom_collection"
+        assert mock_vector_store.upserted[0][0] == "custom_collection"
+        assert result.written.vector_collection == "custom_collection"


### PR DESCRIPTION
## What
Implements `StructuredDBProcessor` — the Path A pipeline for processing Type A tabular Excel files into structured DB tables with embedded schema descriptions in the vector store.

## Why
Issue #8 requires the first processing path for the ingestkit-excel pipeline. Path A handles clean tabular data by writing it to a structured DB and embedding schema descriptions for RAG retrieval.

Closes #8

## How
- `processors/structured_db.py`: Full pipeline — DataFrame load → column cleaning → date parsing → DB write → schema generation → embed → upsert → optional row serialization
- Module-level helpers `clean_name()` and `deduplicate_names()` for DB identifier safety
- Per-sheet error handling with `ErrorCode` classification and continuation
- `WrittenArtifacts` tracking for rollback support

## Stack
- [x] Backend

## Verification
- [x] `pytest -q` passes (335 tests, 0.76s)
- [x] 59 new tests across 11 test classes
- [x] PROVE agent: PASS

## How to Test
1. Run `pytest tests/test_structured_db.py -q` — 59 tests pass
2. Run full suite `pytest -q` — 335 tests pass (no regressions)

## Risks / Rollback
Low risk — isolated new module, no changes to existing processing paths.

---
Artifacts: `.agents/outputs/*-8-021026.md`