### PR TITLE
feat(ingestkit-pdf): Implement PDF error taxonomy (#23)

### DIFF
--- a/.agents/outputs/prove-23-021126.md
+++ b/.agents/outputs/prove-23-021126.md
@@ -1,0 +1,35 @@
+---
+issue: 23
+agent: PROVE
+date: 2026-02-11
+status: PASS
+tests_passed: 110
+tests_failed: 0
+regressions: 0
+---
+
+# PROVE: Issue #23 — Implement PDF error taxonomy
+
+## Verification Results
+
+| Check | Result |
+|-------|--------|
+| `pytest tests/test_errors.py -q` | 61 passed |
+| `pytest tests/ -q` (full suite) | 110 passed (0.42s) |
+| `ruff check src/` | All checks passed |
+| `ruff check tests/` | All checks passed |
+
+## Acceptance Criteria
+
+| Criterion | Status |
+|-----------|--------|
+| All error codes from §5.1 with correct string values | PASS (42 codes) |
+| IngestError uses page_number: int | None | PASS |
+| Stage field accepts valid stages | PASS |
+| pytest passes | PASS |
+| ruff passes | PASS |
+
+## Bonus
+- Updated models.py: `ProcessingResult.error_details` now properly typed as `list[IngestError]`
+
+AGENT_RETURN: .agents/outputs/prove-23-021126.md

--- a/packages/ingestkit-pdf/src/ingestkit_pdf/errors.py
+++ b/packages/ingestkit-pdf/src/ingestkit_pdf/errors.py
@@ -1,0 +1,87 @@
+"""Normalized error codes and structured error model for the ingestkit-pdf pipeline."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class ErrorCode(str, Enum):
+    """Normalized error codes for the ingestkit-pdf pipeline.
+
+    All errors and warnings use a stable string code suitable for metrics,
+    alerting, and programmatic handling. Codes prefixed with ``E_`` are errors;
+    codes prefixed with ``W_`` are non-fatal warnings.
+    """
+
+    # Pre-flight / Security errors
+    E_SECURITY_INVALID_PDF = "E_SECURITY_INVALID_PDF"
+    E_SECURITY_DECOMPRESSION_BOMB = "E_SECURITY_DECOMPRESSION_BOMB"
+    E_SECURITY_JAVASCRIPT = "E_SECURITY_JAVASCRIPT"
+    E_SECURITY_TOO_LARGE = "E_SECURITY_TOO_LARGE"
+    E_SECURITY_TOO_MANY_PAGES = "E_SECURITY_TOO_MANY_PAGES"
+
+    # Parse / Extraction errors
+    E_PARSE_CORRUPT = "E_PARSE_CORRUPT"
+    E_PARSE_PASSWORD = "E_PARSE_PASSWORD"
+    E_PARSE_EMPTY = "E_PARSE_EMPTY"
+    E_PARSE_GARBLED = "E_PARSE_GARBLED"
+    E_PARSE_REPAIR_FAILED = "E_PARSE_REPAIR_FAILED"
+
+    # OCR errors
+    E_OCR_ENGINE_UNAVAILABLE = "E_OCR_ENGINE_UNAVAILABLE"
+    E_OCR_TIMEOUT = "E_OCR_TIMEOUT"
+    E_OCR_FAILED = "E_OCR_FAILED"
+
+    # Classification errors
+    E_CLASSIFY_INCONCLUSIVE = "E_CLASSIFY_INCONCLUSIVE"
+    E_LLM_TIMEOUT = "E_LLM_TIMEOUT"
+    E_LLM_MALFORMED_JSON = "E_LLM_MALFORMED_JSON"
+    E_LLM_SCHEMA_INVALID = "E_LLM_SCHEMA_INVALID"
+    E_LLM_CONFIDENCE_OOB = "E_LLM_CONFIDENCE_OOB"
+
+    # Backend errors
+    E_BACKEND_VECTOR_TIMEOUT = "E_BACKEND_VECTOR_TIMEOUT"
+    E_BACKEND_VECTOR_CONNECT = "E_BACKEND_VECTOR_CONNECT"
+    E_BACKEND_DB_TIMEOUT = "E_BACKEND_DB_TIMEOUT"
+    E_BACKEND_DB_CONNECT = "E_BACKEND_DB_CONNECT"
+    E_BACKEND_EMBED_TIMEOUT = "E_BACKEND_EMBED_TIMEOUT"
+    E_BACKEND_EMBED_CONNECT = "E_BACKEND_EMBED_CONNECT"
+
+    # Processing errors
+    E_PROCESS_TABLE_EXTRACT = "E_PROCESS_TABLE_EXTRACT"
+    E_PROCESS_CHUNK = "E_PROCESS_CHUNK"
+    E_PROCESS_HEADER_FOOTER = "E_PROCESS_HEADER_FOOTER"
+
+    # Warnings (non-fatal)
+    W_PAGE_SKIPPED_BLANK = "W_PAGE_SKIPPED_BLANK"
+    W_PAGE_SKIPPED_TOC = "W_PAGE_SKIPPED_TOC"
+    W_PAGE_SKIPPED_VECTOR_ONLY = "W_PAGE_SKIPPED_VECTOR_ONLY"
+    W_PAGE_LOW_OCR_CONFIDENCE = "W_PAGE_LOW_OCR_CONFIDENCE"
+    W_QUALITY_LOW_NATIVE = "W_QUALITY_LOW_NATIVE"
+    W_OCR_FALLBACK = "W_OCR_FALLBACK"
+    W_OCR_ENGINE_FALLBACK = "W_OCR_ENGINE_FALLBACK"
+    W_TABLE_CONTINUATION = "W_TABLE_CONTINUATION"
+    W_ENCRYPTED_OWNER_ONLY = "W_ENCRYPTED_OWNER_ONLY"
+    W_DOCUMENT_SIGNED = "W_DOCUMENT_SIGNED"
+    W_EMBEDDED_FILES = "W_EMBEDDED_FILES"
+    W_LLM_RETRY = "W_LLM_RETRY"
+    W_LLM_UNAVAILABLE = "W_LLM_UNAVAILABLE"
+    W_CLASSIFICATION_DEGRADED = "W_CLASSIFICATION_DEGRADED"
+    W_SECURITY_OVERRIDE = "W_SECURITY_OVERRIDE"
+
+
+class IngestError(BaseModel):
+    """Structured error with code, message, and context.
+
+    Unlike the Excel variant (which uses ``sheet_name``), the PDF variant
+    uses ``page_number`` to identify the location of the error within the
+    document.
+    """
+
+    code: ErrorCode
+    message: str
+    page_number: int | None = None
+    stage: str | None = None
+    recoverable: bool = False

--- a/packages/ingestkit-pdf/src/ingestkit_pdf/models.py
+++ b/packages/ingestkit-pdf/src/ingestkit_pdf/models.py
@@ -14,6 +14,8 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from ingestkit_pdf.errors import IngestError
+
 
 # ---------------------------------------------------------------------------
 # Enumerations
@@ -371,6 +373,6 @@ class ProcessingResult(BaseModel):
 
     errors: list[str]
     warnings: list[str]
-    error_details: list[Any] = []  # list[IngestError] once errors.py (#23) exists
+    error_details: list[IngestError] = []
 
     processing_time_seconds: float

--- a/packages/ingestkit-pdf/tests/test_errors.py
+++ b/packages/ingestkit-pdf/tests/test_errors.py
@@ -1,0 +1,154 @@
+"""Tests for ingestkit_pdf.errors — error codes and IngestError model."""
+
+from __future__ import annotations
+
+import pytest
+
+from ingestkit_pdf.errors import ErrorCode, IngestError
+
+
+# ---------------------------------------------------------------------------
+# ErrorCode Enum Tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorCodeValues:
+    """Verify all error codes have correct string values matching their names."""
+
+    @pytest.mark.parametrize(
+        "member",
+        list(ErrorCode),
+        ids=[m.name for m in ErrorCode],
+    )
+    def test_value_equals_name(self, member: ErrorCode):
+        assert member.value == member.name
+
+    def test_security_error_count(self):
+        security = [c for c in ErrorCode if c.value.startswith("E_SECURITY_")]
+        assert len(security) == 5
+
+    def test_parse_error_count(self):
+        parse = [c for c in ErrorCode if c.value.startswith("E_PARSE_")]
+        assert len(parse) == 5
+
+    def test_ocr_error_count(self):
+        ocr = [c for c in ErrorCode if c.value.startswith("E_OCR_")]
+        assert len(ocr) == 3
+
+    def test_classify_and_llm_error_count(self):
+        classify = [
+            c
+            for c in ErrorCode
+            if c.value.startswith("E_CLASSIFY_") or c.value.startswith("E_LLM_")
+        ]
+        assert len(classify) == 5
+
+    def test_backend_error_count(self):
+        backend = [c for c in ErrorCode if c.value.startswith("E_BACKEND_")]
+        assert len(backend) == 6
+
+    def test_process_error_count(self):
+        process = [c for c in ErrorCode if c.value.startswith("E_PROCESS_")]
+        assert len(process) == 3
+
+    def test_warning_count(self):
+        warnings = [c for c in ErrorCode if c.value.startswith("W_")]
+        assert len(warnings) == 15
+
+    def test_total_member_count(self):
+        assert len(ErrorCode) == 42
+
+    def test_all_errors_prefixed(self):
+        for code in ErrorCode:
+            assert code.value.startswith("E_") or code.value.startswith("W_"), (
+                f"{code.name} missing E_/W_ prefix"
+            )
+
+
+class TestErrorCodeLookup:
+    def test_lookup_by_value(self):
+        assert ErrorCode("E_SECURITY_INVALID_PDF") == ErrorCode.E_SECURITY_INVALID_PDF
+
+    def test_lookup_by_name(self):
+        assert ErrorCode["E_PARSE_CORRUPT"] == ErrorCode.E_PARSE_CORRUPT
+
+    def test_string_comparison(self):
+        assert ErrorCode.W_OCR_FALLBACK == "W_OCR_FALLBACK"
+
+
+# ---------------------------------------------------------------------------
+# IngestError Model Tests
+# ---------------------------------------------------------------------------
+
+
+class TestIngestError:
+    def test_minimal(self):
+        e = IngestError(
+            code=ErrorCode.E_PARSE_CORRUPT,
+            message="PyMuPDF cannot open file",
+        )
+        assert e.code == ErrorCode.E_PARSE_CORRUPT
+        assert e.page_number is None
+        assert e.stage is None
+        assert e.recoverable is False
+
+    def test_with_page_number(self):
+        e = IngestError(
+            code=ErrorCode.E_OCR_TIMEOUT,
+            message="OCR exceeded timeout on page 5",
+            page_number=5,
+            stage="ocr",
+        )
+        assert e.page_number == 5
+        assert e.stage == "ocr"
+
+    def test_recoverable_warning(self):
+        e = IngestError(
+            code=ErrorCode.W_PAGE_SKIPPED_BLANK,
+            message="Page 3 is blank, skipping",
+            page_number=3,
+            stage="parse",
+            recoverable=True,
+        )
+        assert e.recoverable is True
+
+    def test_all_valid_stages(self):
+        stages = ["security", "parse", "ocr", "classify", "process", "embed"]
+        for stage in stages:
+            e = IngestError(
+                code=ErrorCode.E_PARSE_EMPTY,
+                message="test",
+                stage=stage,
+            )
+            assert e.stage == stage
+
+    def test_serialization_round_trip(self):
+        e = IngestError(
+            code=ErrorCode.W_LLM_UNAVAILABLE,
+            message="LLM backend unreachable",
+            stage="classify",
+            recoverable=True,
+        )
+        data = e.model_dump()
+        e2 = IngestError.model_validate(data)
+        assert e2.code == e.code
+        assert e2.message == e.message
+        assert e2.recoverable is True
+
+    def test_security_override_warning(self):
+        e = IngestError(
+            code=ErrorCode.W_SECURITY_OVERRIDE,
+            message="reject_javascript overridden: TICKET-4521",
+            stage="security",
+            recoverable=True,
+        )
+        assert e.code == ErrorCode.W_SECURITY_OVERRIDE
+
+    def test_classification_degraded_warning(self):
+        e = IngestError(
+            code=ErrorCode.W_CLASSIFICATION_DEGRADED,
+            message="LLM unavailable, using Tier 1 only",
+            stage="classify",
+            recoverable=True,
+        )
+        assert e.code == ErrorCode.W_CLASSIFICATION_DEGRADED


### PR DESCRIPTION
## What
PDF-specific error taxonomy: ErrorCode enum (42 codes) and IngestError Pydantic model with page-level context.

## Why
Required by all pipeline modules for structured error reporting. Also unblocks proper typing of `ProcessingResult.error_details`.

Closes #23

## How
- Translated SPEC.md §5.1-§5.2 error codes into `ErrorCode(str, Enum)`
- Created `IngestError` model with `page_number` (PDF-specific, vs Excel's `sheet_name`)
- Updated `models.py` to import and use `IngestError` for `ProcessingResult.error_details`

## Stack
- [x] Backend

## Verification
- [x] `ruff check .` passes
- [x] `pytest tests/test_errors.py -q` passes (61 tests)
- [x] Full PDF suite: 110 tests pass

## How to Test
1. `cd packages/ingestkit-pdf && .venv/bin/pytest tests/test_errors.py -q`

## Risks / Rollback
Low risk — new module + minor typing fix to models.py.

---
Artifacts: `.agents/outputs/prove-23-021126.md`