### PR TITLE
feat(ingestkit-pdf): Implement PDF configuration (#24)

### DIFF
--- a/packages/ingestkit-pdf/src/ingestkit_pdf/config.py
+++ b/packages/ingestkit-pdf/src/ingestkit_pdf/config.py
@@ -1,0 +1,183 @@
+"""Configuration model for the ingestkit-pdf pipeline.
+
+Provides ``PDFProcessorConfig`` with all tunable parameters and sensible
+defaults drawn from the specification.  Supports loading overrides from YAML
+or JSON files via the ``from_file()`` classmethod.
+
+Security override governance (§7.5): disabling any security default
+requires an explicit reason string in the corresponding
+``*_override_reason`` field, enforced via Pydantic model validators.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+from pydantic import BaseModel, model_validator
+
+from ingestkit_pdf.models import OCREngine
+
+
+class PDFProcessorConfig(BaseModel):
+    """All tunable parameters with sensible defaults.
+
+    Every field matches the default value specified in SPEC.md §6.
+    Override individual values via constructor kwargs or load a complete
+    config from a file with ``PDFProcessorConfig.from_file(path)``.
+    """
+
+    # --- Identity ---
+    parser_version: str = "ingestkit_pdf:1.0.0"
+    tenant_id: str | None = None
+
+    # --- Security / Resource Limits ---
+    max_file_size_mb: int = 500
+    max_page_count: int = 5000
+    per_document_timeout_seconds: int = 300
+    max_decompression_ratio: int = 100
+    reject_javascript: bool = True
+
+    # --- Security Override Governance ---
+    reject_javascript_override_reason: str | None = None
+    max_file_size_override_reason: str | None = None
+    max_page_count_override_reason: str | None = None
+
+    # --- Tier 1 Thresholds ---
+    min_chars_per_page: int = 200
+    max_image_coverage_for_text: float = 0.3
+    min_table_count_for_complex: int = 1
+    min_font_count_for_digital: int = 1
+    tier1_high_confidence_signals: int = 4
+    tier1_medium_confidence_signals: int = 3
+
+    # --- Tier 2/3 LLM Settings ---
+    classification_model: str = "qwen2.5:7b"
+    reasoning_model: str = "deepseek-r1:14b"
+    tier2_confidence_threshold: float = 0.6
+    llm_temperature: float = 0.1
+    enable_tier3: bool = True
+
+    # --- OCR Settings ---
+    ocr_engine: OCREngine = OCREngine.TESSERACT
+    ocr_dpi: int = 300
+    ocr_language: str = "en"
+    ocr_confidence_threshold: float = 0.7
+    ocr_preprocessing_steps: list[str] = ["deskew"]
+    ocr_max_workers: int = 4
+    ocr_per_page_timeout_seconds: int = 60
+    enable_ocr_cleanup: bool = False
+    ocr_cleanup_model: str = "qwen2.5:7b"
+
+    # --- Extraction Quality ---
+    quality_min_printable_ratio: float = 0.85
+    quality_min_words_per_page: int = 10
+    auto_ocr_fallback: bool = True
+
+    # --- Header/Footer Detection ---
+    header_footer_sample_pages: int = 5
+    header_footer_zone_ratio: float = 0.10
+    header_footer_similarity_threshold: float = 0.7
+
+    # --- Heading Detection ---
+    heading_min_font_size_ratio: float = 1.2
+
+    # --- Table Extraction ---
+    table_max_rows_for_serialization: int = 20
+    table_min_rows_for_db: int = 20
+    table_continuation_column_match_threshold: float = 0.8
+
+    # --- Chunking ---
+    chunk_size_tokens: int = 512
+    chunk_overlap_tokens: int = 50
+    chunk_respect_headings: bool = True
+    chunk_respect_tables: bool = True
+
+    # --- Embedding ---
+    embedding_model: str = "nomic-embed-text"
+    embedding_dimension: int = 768
+    embedding_batch_size: int = 64
+
+    # --- Vector Store ---
+    default_collection: str = "helpdesk"
+
+    # --- Language Detection ---
+    enable_language_detection: bool = True
+    default_language: str = "en"
+
+    # --- Deduplication ---
+    enable_content_dedup: bool = True
+
+    # --- Backend Resilience ---
+    backend_timeout_seconds: float = 30.0
+    backend_max_retries: int = 2
+    backend_backoff_base: float = 1.0
+
+    # --- Logging / PII Safety ---
+    log_sample_text: bool = False
+    log_llm_prompts: bool = False
+    log_chunk_previews: bool = False
+    log_ocr_output: bool = False
+    redact_patterns: list[str] = []
+
+    @model_validator(mode="after")
+    def _validate_security_overrides(self) -> PDFProcessorConfig:
+        """Enforce security override governance (§7.5).
+
+        Disabling a security default without providing an explicit reason
+        string raises a ValidationError.
+        """
+        if not self.reject_javascript and self.reject_javascript_override_reason is None:
+            raise ValueError(
+                "reject_javascript=False requires reject_javascript_override_reason "
+                "to be set (see SPEC §7.5 Security Override Governance)"
+            )
+        if self.max_file_size_mb > 500 and self.max_file_size_override_reason is None:
+            raise ValueError(
+                "max_file_size_mb > 500 requires max_file_size_override_reason "
+                "to be set (see SPEC §7.5 Security Override Governance)"
+            )
+        if self.max_page_count > 5000 and self.max_page_count_override_reason is None:
+            raise ValueError(
+                "max_page_count > 5000 requires max_page_count_override_reason "
+                "to be set (see SPEC §7.5 Security Override Governance)"
+            )
+        return self
+
+    @classmethod
+    def from_file(cls, path: str) -> PDFProcessorConfig:
+        """Load configuration from a YAML or JSON file.
+
+        File format is detected by extension: ``.yaml`` / ``.yml`` for YAML,
+        ``.json`` for JSON.  Any keys present in the file override the
+        corresponding defaults; keys not present retain their defaults.
+        """
+        file_path = pathlib.Path(path)
+        if not file_path.exists():
+            raise FileNotFoundError(f"Config file not found: {path}")
+
+        suffix = file_path.suffix.lower()
+
+        if suffix in (".yaml", ".yml"):
+            try:
+                import yaml  # type: ignore[import-untyped]
+            except ImportError as exc:
+                raise ImportError(
+                    "pyyaml is required to load YAML config files. "
+                    "Install it with: pip install pyyaml"
+                ) from exc
+            with open(file_path) as fh:
+                data = yaml.safe_load(fh)
+        elif suffix == ".json":
+            with open(file_path) as fh:
+                data = json.load(fh)
+        else:
+            raise ValueError(
+                f"Unsupported config file extension '{suffix}'. "
+                "Use .yaml, .yml, or .json."
+            )
+
+        if data is None:
+            data = {}
+
+        return cls(**data)

--- a/packages/ingestkit-pdf/tests/test_config.py
+++ b/packages/ingestkit-pdf/tests/test_config.py
@@ -1,0 +1,311 @@
+"""Tests for ingestkit_pdf.config — PDFProcessorConfig defaults, validators, and file loading."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+
+import pytest
+
+from ingestkit_pdf.config import PDFProcessorConfig
+from ingestkit_pdf.models import OCREngine
+
+
+# ---------------------------------------------------------------------------
+# Default Values
+# ---------------------------------------------------------------------------
+
+
+class TestDefaults:
+    def test_identity(self):
+        c = PDFProcessorConfig()
+        assert c.parser_version == "ingestkit_pdf:1.0.0"
+        assert c.tenant_id is None
+
+    def test_security_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.max_file_size_mb == 500
+        assert c.max_page_count == 5000
+        assert c.per_document_timeout_seconds == 300
+        assert c.max_decompression_ratio == 100
+        assert c.reject_javascript is True
+
+    def test_security_override_defaults_none(self):
+        c = PDFProcessorConfig()
+        assert c.reject_javascript_override_reason is None
+        assert c.max_file_size_override_reason is None
+        assert c.max_page_count_override_reason is None
+
+    def test_tier1_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.min_chars_per_page == 200
+        assert c.max_image_coverage_for_text == 0.3
+        assert c.min_table_count_for_complex == 1
+        assert c.min_font_count_for_digital == 1
+        assert c.tier1_high_confidence_signals == 4
+        assert c.tier1_medium_confidence_signals == 3
+
+    def test_tier2_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.classification_model == "qwen2.5:7b"
+        assert c.reasoning_model == "deepseek-r1:14b"
+        assert c.tier2_confidence_threshold == 0.6
+        assert c.llm_temperature == 0.1
+        assert c.enable_tier3 is True
+
+    def test_ocr_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.ocr_engine == OCREngine.TESSERACT
+        assert c.ocr_dpi == 300
+        assert c.ocr_language == "en"
+        assert c.ocr_confidence_threshold == 0.7
+        assert c.ocr_preprocessing_steps == ["deskew"]
+        assert c.ocr_max_workers == 4
+        assert c.ocr_per_page_timeout_seconds == 60
+        assert c.enable_ocr_cleanup is False
+        assert c.ocr_cleanup_model == "qwen2.5:7b"
+
+    def test_quality_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.quality_min_printable_ratio == 0.85
+        assert c.quality_min_words_per_page == 10
+        assert c.auto_ocr_fallback is True
+
+    def test_header_footer_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.header_footer_sample_pages == 5
+        assert c.header_footer_zone_ratio == 0.10
+        assert c.header_footer_similarity_threshold == 0.7
+
+    def test_heading_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.heading_min_font_size_ratio == 1.2
+
+    def test_table_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.table_max_rows_for_serialization == 20
+        assert c.table_min_rows_for_db == 20
+        assert c.table_continuation_column_match_threshold == 0.8
+
+    def test_chunking_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.chunk_size_tokens == 512
+        assert c.chunk_overlap_tokens == 50
+        assert c.chunk_respect_headings is True
+        assert c.chunk_respect_tables is True
+
+    def test_embedding_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.embedding_model == "nomic-embed-text"
+        assert c.embedding_dimension == 768
+        assert c.embedding_batch_size == 64
+
+    def test_vector_store_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.default_collection == "helpdesk"
+
+    def test_language_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.enable_language_detection is True
+        assert c.default_language == "en"
+
+    def test_dedup_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.enable_content_dedup is True
+
+    def test_backend_resilience_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.backend_timeout_seconds == 30.0
+        assert c.backend_max_retries == 2
+        assert c.backend_backoff_base == 1.0
+
+    def test_logging_defaults(self):
+        c = PDFProcessorConfig()
+        assert c.log_sample_text is False
+        assert c.log_llm_prompts is False
+        assert c.log_chunk_previews is False
+        assert c.log_ocr_output is False
+        assert c.redact_patterns == []
+
+
+# ---------------------------------------------------------------------------
+# Security Override Governance
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityOverrides:
+    def test_reject_javascript_false_without_reason_raises(self):
+        with pytest.raises(ValueError, match="reject_javascript_override_reason"):
+            PDFProcessorConfig(reject_javascript=False)
+
+    def test_reject_javascript_false_with_reason_succeeds(self):
+        c = PDFProcessorConfig(
+            reject_javascript=False,
+            reject_javascript_override_reason="TICKET-4521: Legacy HR forms",
+        )
+        assert c.reject_javascript is False
+        assert c.reject_javascript_override_reason == "TICKET-4521: Legacy HR forms"
+
+    def test_reject_javascript_true_no_reason_needed(self):
+        c = PDFProcessorConfig(reject_javascript=True)
+        assert c.reject_javascript is True
+
+    def test_max_file_size_override_without_reason_raises(self):
+        with pytest.raises(ValueError, match="max_file_size_override_reason"):
+            PDFProcessorConfig(max_file_size_mb=1000)
+
+    def test_max_file_size_override_with_reason_succeeds(self):
+        c = PDFProcessorConfig(
+            max_file_size_mb=1000,
+            max_file_size_override_reason="TICKET-4530: Annual compliance bundle",
+        )
+        assert c.max_file_size_mb == 1000
+
+    def test_max_file_size_at_default_no_reason_needed(self):
+        c = PDFProcessorConfig(max_file_size_mb=500)
+        assert c.max_file_size_mb == 500
+
+    def test_max_file_size_below_default_no_reason_needed(self):
+        c = PDFProcessorConfig(max_file_size_mb=100)
+        assert c.max_file_size_mb == 100
+
+    def test_max_page_count_override_without_reason_raises(self):
+        with pytest.raises(ValueError, match="max_page_count_override_reason"):
+            PDFProcessorConfig(max_page_count=10000)
+
+    def test_max_page_count_override_with_reason_succeeds(self):
+        c = PDFProcessorConfig(
+            max_page_count=10000,
+            max_page_count_override_reason="TICKET-4540: Large document set",
+        )
+        assert c.max_page_count == 10000
+
+    def test_max_page_count_at_default_no_reason_needed(self):
+        c = PDFProcessorConfig(max_page_count=5000)
+        assert c.max_page_count == 5000
+
+    def test_multiple_overrides(self):
+        c = PDFProcessorConfig(
+            reject_javascript=False,
+            reject_javascript_override_reason="TICKET-1",
+            max_file_size_mb=2000,
+            max_file_size_override_reason="TICKET-2",
+            max_page_count=20000,
+            max_page_count_override_reason="TICKET-3",
+        )
+        assert c.reject_javascript is False
+        assert c.max_file_size_mb == 2000
+        assert c.max_page_count == 20000
+
+
+# ---------------------------------------------------------------------------
+# Override via Constructor
+# ---------------------------------------------------------------------------
+
+
+class TestOverrides:
+    def test_override_single_field(self):
+        c = PDFProcessorConfig(ocr_dpi=600)
+        assert c.ocr_dpi == 600
+        assert c.ocr_engine == OCREngine.TESSERACT  # others unchanged
+
+    def test_override_ocr_engine(self):
+        c = PDFProcessorConfig(ocr_engine=OCREngine.PADDLEOCR)
+        assert c.ocr_engine == OCREngine.PADDLEOCR
+
+    def test_override_chunking(self):
+        c = PDFProcessorConfig(chunk_size_tokens=1024, chunk_overlap_tokens=100)
+        assert c.chunk_size_tokens == 1024
+        assert c.chunk_overlap_tokens == 100
+
+
+# ---------------------------------------------------------------------------
+# File Loading
+# ---------------------------------------------------------------------------
+
+
+class TestFromFile:
+    def test_load_json(self, tmp_path):
+        config_data = {"ocr_dpi": 600, "chunk_size_tokens": 1024}
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config_data))
+        c = PDFProcessorConfig.from_file(str(config_file))
+        assert c.ocr_dpi == 600
+        assert c.chunk_size_tokens == 1024
+        assert c.max_file_size_mb == 500  # default preserved
+
+    def test_load_yaml(self, tmp_path):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            textwrap.dedent("""\
+            ocr_dpi: 600
+            chunk_size_tokens: 1024
+            """)
+        )
+        c = PDFProcessorConfig.from_file(str(config_file))
+        assert c.ocr_dpi == 600
+        assert c.chunk_size_tokens == 1024
+
+    def test_load_yml_extension(self, tmp_path):
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("ocr_dpi: 400\n")
+        c = PDFProcessorConfig.from_file(str(config_file))
+        assert c.ocr_dpi == 400
+
+    def test_empty_yaml(self, tmp_path):
+        config_file = tmp_path / "empty.yaml"
+        config_file.write_text("")
+        c = PDFProcessorConfig.from_file(str(config_file))
+        assert c.max_file_size_mb == 500  # all defaults
+
+    def test_empty_json(self, tmp_path):
+        config_file = tmp_path / "empty.json"
+        config_file.write_text("{}")
+        c = PDFProcessorConfig.from_file(str(config_file))
+        assert c.max_file_size_mb == 500
+
+    def test_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            PDFProcessorConfig.from_file("/nonexistent/config.yaml")
+
+    def test_unsupported_extension(self, tmp_path):
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("")
+        with pytest.raises(ValueError, match="Unsupported"):
+            PDFProcessorConfig.from_file(str(config_file))
+
+    def test_security_override_via_file(self, tmp_path):
+        config_data = {
+            "reject_javascript": False,
+            "reject_javascript_override_reason": "TICKET-99",
+        }
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config_data))
+        c = PDFProcessorConfig.from_file(str(config_file))
+        assert c.reject_javascript is False
+
+    def test_security_override_missing_reason_via_file(self, tmp_path):
+        config_data = {"reject_javascript": False}
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config_data))
+        with pytest.raises(ValueError, match="reject_javascript_override_reason"):
+            PDFProcessorConfig.from_file(str(config_file))
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def test_round_trip(self):
+        c = PDFProcessorConfig(ocr_dpi=600, tenant_id="t1")
+        data = c.model_dump()
+        c2 = PDFProcessorConfig.model_validate(data)
+        assert c2.ocr_dpi == 600
+        assert c2.tenant_id == "t1"
+
+    def test_ocr_engine_serializes_as_string(self):
+        c = PDFProcessorConfig()
+        data = c.model_dump()
+        assert data["ocr_engine"] == "tesseract"


### PR DESCRIPTION
## What
PDFProcessorConfig with all tunable parameters and security override governance validators.

## Why
Central configuration for all pipeline modules. Security override governance ensures disabling protections requires explicit justification.

Closes #24

## How
- Translated SPEC.md §6 into Pydantic v2 BaseModel with ~50 config fields
- Added `model_validator` enforcing §7.5 security override governance (3 validators)
- `from_file()` classmethod supports YAML/JSON loading (same pattern as Excel)
- OCR engine defaults to TESSERACT per v1.1 spec

## Stack
- [x] Backend

## Verification
- [x] `ruff check .` passes
- [x] `pytest tests/test_config.py -q` passes (42 tests)
- [x] Full PDF suite: 152 tests pass

## How to Test
1. `cd packages/ingestkit-pdf && .venv/bin/pytest tests/test_config.py -q`
2. Verify security override: `PDFProcessorConfig(reject_javascript=False)` raises ValidationError

## Risks / Rollback
Low risk — new module, no existing code modified.