### PR TITLE
feat(ingestkit-pdf): Implement pre-flight security scanner (#26)

### DIFF
--- a/packages/ingestkit-pdf/src/ingestkit_pdf/security.py
+++ b/packages/ingestkit-pdf/src/ingestkit_pdf/security.py
@@ -1,0 +1,301 @@
+"""Pre-flight security scanner for PDF files.
+
+Rejects dangerous or oversized PDFs before any extraction begins.
+Implements the checks from SPEC §7.1-§7.5 including magic byte validation,
+size/page limits, JavaScript detection, decompression bomb detection,
+encryption handling, and security override governance with audit logging.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import fitz  # PyMuPDF
+
+from ingestkit_pdf.config import PDFProcessorConfig
+from ingestkit_pdf.errors import ErrorCode, IngestError
+from ingestkit_pdf.models import DocumentMetadata
+
+logger = logging.getLogger("ingestkit_pdf")
+
+_PDF_MAGIC = b"%PDF-"
+
+
+class PDFSecurityScanner:
+    """Run pre-flight security checks on a PDF file.
+
+    Returns document metadata and a list of errors/warnings. Fatal errors
+    (``E_*`` codes) mean the file should not be processed further.
+    """
+
+    def __init__(self, config: PDFProcessorConfig) -> None:
+        self.config = config
+
+    def scan(self, file_path: str) -> tuple[DocumentMetadata, list[IngestError]]:
+        """Run all pre-flight checks.
+
+        Returns:
+            A tuple of (DocumentMetadata, list of errors/warnings).
+            Fatal errors have codes starting with ``E_``.
+        """
+        errors: list[IngestError] = []
+        metadata = DocumentMetadata()
+
+        # --- 1. Magic bytes ---
+        if not self._check_magic_bytes(file_path):
+            errors.append(
+                IngestError(
+                    code=ErrorCode.E_SECURITY_INVALID_PDF,
+                    message=f"File does not start with %PDF- magic bytes: {file_path}",
+                    stage="security",
+                )
+            )
+            return metadata, errors
+
+        # --- 2. File size ---
+        file_size = os.path.getsize(file_path)
+        metadata.file_size_bytes = file_size
+
+        max_bytes = self.config.max_file_size_mb * 1024 * 1024
+        if file_size > max_bytes:
+            if self.config.max_file_size_override_reason:
+                self._log_override(file_path, "max_file_size_mb", self.config.max_file_size_override_reason)
+                errors.append(
+                    IngestError(
+                        code=ErrorCode.W_SECURITY_OVERRIDE,
+                        message=(
+                            f"max_file_size_mb override: file is {file_size} bytes "
+                            f"(limit {max_bytes}), reason: {self.config.max_file_size_override_reason}"
+                        ),
+                        stage="security",
+                        recoverable=True,
+                    )
+                )
+            else:
+                errors.append(
+                    IngestError(
+                        code=ErrorCode.E_SECURITY_TOO_LARGE,
+                        message=f"File size {file_size} bytes exceeds limit of {max_bytes} bytes",
+                        stage="security",
+                    )
+                )
+                return metadata, errors
+
+        # --- 3. Open with PyMuPDF ---
+        try:
+            doc = fitz.open(file_path)
+        except Exception as exc:
+            errors.append(
+                IngestError(
+                    code=ErrorCode.E_PARSE_CORRUPT,
+                    message=f"PyMuPDF cannot open file: {exc}",
+                    stage="security",
+                )
+            )
+            return metadata, errors
+
+        try:
+            metadata = self._extract_metadata(doc, file_path, file_size)
+
+            # --- 4. Encryption check ---
+            if doc.needs_pass:
+                if doc.authenticate(""):
+                    metadata.is_encrypted = True
+                    metadata.needs_password = False
+                else:
+                    metadata.is_encrypted = True
+                    metadata.needs_password = True
+                    errors.append(
+                        IngestError(
+                            code=ErrorCode.E_PARSE_PASSWORD,
+                            message="PDF requires a password to open",
+                            stage="security",
+                        )
+                    )
+                    return metadata, errors
+
+            # --- 5. Page count ---
+            if doc.page_count > self.config.max_page_count:
+                if self.config.max_page_count_override_reason:
+                    self._log_override(file_path, "max_page_count", self.config.max_page_count_override_reason)
+                    errors.append(
+                        IngestError(
+                            code=ErrorCode.W_SECURITY_OVERRIDE,
+                            message=(
+                                f"max_page_count override: {doc.page_count} pages "
+                                f"(limit {self.config.max_page_count}), "
+                                f"reason: {self.config.max_page_count_override_reason}"
+                            ),
+                            stage="security",
+                            recoverable=True,
+                        )
+                    )
+                else:
+                    errors.append(
+                        IngestError(
+                            code=ErrorCode.E_SECURITY_TOO_MANY_PAGES,
+                            message=(
+                                f"Page count {doc.page_count} exceeds limit "
+                                f"of {self.config.max_page_count}"
+                            ),
+                            stage="security",
+                        )
+                    )
+                    return metadata, errors
+
+            # --- 6. Zero pages ---
+            if doc.page_count == 0:
+                errors.append(
+                    IngestError(
+                        code=ErrorCode.E_PARSE_EMPTY,
+                        message="PDF has zero pages",
+                        stage="security",
+                    )
+                )
+                return metadata, errors
+
+            # --- 7. Decompression bomb detection ---
+            xref_count = doc.xref_length()
+            if xref_count > self.config.max_decompression_ratio * 1000:
+                errors.append(
+                    IngestError(
+                        code=ErrorCode.E_SECURITY_DECOMPRESSION_BOMB,
+                        message=(
+                            f"Excessive xref objects ({xref_count}), "
+                            f"possible decompression bomb"
+                        ),
+                        stage="security",
+                    )
+                )
+                return metadata, errors
+
+            # --- 8. JavaScript detection ---
+            has_js = self._detect_javascript(doc)
+            if has_js:
+                if self.config.reject_javascript:
+                    errors.append(
+                        IngestError(
+                            code=ErrorCode.E_SECURITY_JAVASCRIPT,
+                            message="Embedded JavaScript detected in PDF",
+                            stage="security",
+                        )
+                    )
+                    return metadata, errors
+                elif self.config.reject_javascript_override_reason:
+                    self._log_override(file_path, "reject_javascript", self.config.reject_javascript_override_reason)
+                    errors.append(
+                        IngestError(
+                            code=ErrorCode.W_SECURITY_OVERRIDE,
+                            message=(
+                                f"reject_javascript override: JS detected, "
+                                f"reason: {self.config.reject_javascript_override_reason}"
+                            ),
+                            stage="security",
+                            recoverable=True,
+                        )
+                    )
+
+            # --- 9. Signed PDF detection ---
+            if metadata.is_signed:
+                errors.append(
+                    IngestError(
+                        code=ErrorCode.W_DOCUMENT_SIGNED,
+                        message="PDF is digitally signed, read-only extraction",
+                        stage="security",
+                        recoverable=True,
+                    )
+                )
+
+            # --- 10. Embedded files detection ---
+            if doc.embfile_count() > 0:
+                errors.append(
+                    IngestError(
+                        code=ErrorCode.W_EMBEDDED_FILES,
+                        message=f"PDF contains {doc.embfile_count()} embedded file(s), not processed",
+                        stage="security",
+                        recoverable=True,
+                    )
+                )
+
+        finally:
+            doc.close()
+
+        return metadata, errors
+
+    @staticmethod
+    def _check_magic_bytes(file_path: str) -> bool:
+        """Check if the file starts with %PDF- magic bytes."""
+        try:
+            with open(file_path, "rb") as f:
+                header = f.read(len(_PDF_MAGIC))
+            return header == _PDF_MAGIC
+        except OSError:
+            return False
+
+    def _extract_metadata(
+        self, doc: fitz.Document, file_path: str, file_size: int
+    ) -> DocumentMetadata:
+        """Extract document metadata from a PyMuPDF document."""
+        meta = doc.metadata or {}
+
+        is_signed = self._detect_signatures(doc)
+        encryption = meta.get("encryption")
+        is_encrypted = bool(encryption) and encryption != "none"
+
+        return DocumentMetadata(
+            title=meta.get("title") or None,
+            author=meta.get("author") or None,
+            subject=meta.get("subject") or None,
+            keywords=meta.get("keywords") or None,
+            creator=meta.get("creator") or None,
+            producer=meta.get("producer") or None,
+            creation_date=meta.get("creationDate") or None,
+            modification_date=meta.get("modDate") or None,
+            pdf_version=meta.get("format") or None,
+            page_count=doc.page_count,
+            file_size_bytes=file_size,
+            is_encrypted=is_encrypted,
+            needs_password=bool(doc.needs_pass),
+            is_signed=is_signed,
+            has_form_fields=doc.is_form_pdf,
+            is_linearized=bool(doc.is_fast_webaccess),
+        )
+
+    @staticmethod
+    def _detect_javascript(doc: fitz.Document) -> bool:
+        """Scan xref objects for embedded JavaScript."""
+        for xref in range(1, doc.xref_length()):
+            try:
+                keys = doc.xref_get_keys(xref)
+                if "JS" in keys or "JavaScript" in keys:
+                    return True
+                obj_type = doc.xref_get_key(xref, "S")
+                if obj_type and obj_type[1] == "/JavaScript":
+                    return True
+            except Exception:
+                continue
+        return False
+
+    @staticmethod
+    def _detect_signatures(doc: fitz.Document) -> bool:
+        """Detect digital signatures by scanning for /Sig form fields."""
+        for page_num in range(doc.page_count):
+            try:
+                page = doc[page_num]
+                for widget in page.widgets() or []:
+                    if widget.field_type_string == "Signature":
+                        return True
+            except Exception:
+                continue
+        return False
+
+    @staticmethod
+    def _log_override(file_path: str, override_name: str, reason: str) -> None:
+        """Emit a W_SECURITY_OVERRIDE audit log entry."""
+        logger.warning(
+            "ingestkit_pdf | SECURITY_OVERRIDE | file=%s | override=%s | reason=%r | config_source=config",
+            os.path.basename(file_path),
+            override_name,
+            reason,
+        )

--- a/packages/ingestkit-pdf/tests/test_security.py
+++ b/packages/ingestkit-pdf/tests/test_security.py
@@ -1,0 +1,360 @@
+"""Tests for ingestkit_pdf.security — pre-flight security scanner.
+
+All test PDFs are generated programmatically (no binary fixtures).
+"""
+
+from __future__ import annotations
+
+import io
+
+import fitz  # PyMuPDF
+import pytest
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+from ingestkit_pdf.config import PDFProcessorConfig
+from ingestkit_pdf.errors import ErrorCode
+from ingestkit_pdf.security import PDFSecurityScanner
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — programmatic PDF generation
+# ---------------------------------------------------------------------------
+
+
+def _make_simple_pdf(num_pages: int = 1, text: str = "Hello World") -> bytes:
+    """Generate a simple PDF with N pages using reportlab."""
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf, pagesize=letter)
+    for i in range(num_pages):
+        c.drawString(100, 700, f"{text} - page {i + 1}")
+        c.showPage()
+    c.save()
+    return buf.getvalue()
+
+
+def _write_pdf(tmp_path, content: bytes, name: str = "test.pdf") -> str:
+    """Write PDF bytes to a temp file and return the path."""
+    path = tmp_path / name
+    path.write_bytes(content)
+    return str(path)
+
+
+@pytest.fixture
+def scanner():
+    """Scanner with default config."""
+    return PDFSecurityScanner(PDFProcessorConfig())
+
+
+@pytest.fixture
+def simple_pdf(tmp_path):
+    """Path to a valid single-page PDF."""
+    return _write_pdf(tmp_path, _make_simple_pdf())
+
+
+# ---------------------------------------------------------------------------
+# Valid PDF Tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidPDF:
+    def test_accepts_valid_pdf(self, scanner, simple_pdf):
+        metadata, errors = scanner.scan(simple_pdf)
+        fatal = [e for e in errors if e.code.value.startswith("E_")]
+        assert len(fatal) == 0
+        assert metadata.page_count == 1
+        assert metadata.file_size_bytes > 0
+
+    def test_multi_page_pdf(self, scanner, tmp_path):
+        path = _write_pdf(tmp_path, _make_simple_pdf(num_pages=5))
+        metadata, errors = scanner.scan(path)
+        fatal = [e for e in errors if e.code.value.startswith("E_")]
+        assert len(fatal) == 0
+        assert metadata.page_count == 5
+
+    def test_metadata_extracted(self, scanner, simple_pdf):
+        metadata, _ = scanner.scan(simple_pdf)
+        assert metadata.pdf_version is not None
+        assert metadata.is_encrypted is False
+        assert metadata.needs_password is False
+        assert metadata.is_linearized is False
+
+
+# ---------------------------------------------------------------------------
+# Magic Bytes Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMagicBytes:
+    def test_invalid_magic_bytes(self, scanner, tmp_path):
+        path = _write_pdf(tmp_path, b"NOT A PDF FILE CONTENT", name="bad.pdf")
+        metadata, errors = scanner.scan(path)
+        assert len(errors) == 1
+        assert errors[0].code == ErrorCode.E_SECURITY_INVALID_PDF
+
+    def test_empty_file(self, scanner, tmp_path):
+        path = _write_pdf(tmp_path, b"", name="empty.pdf")
+        metadata, errors = scanner.scan(path)
+        assert any(e.code == ErrorCode.E_SECURITY_INVALID_PDF for e in errors)
+
+    def test_truncated_header(self, scanner, tmp_path):
+        path = _write_pdf(tmp_path, b"%PD", name="truncated.pdf")
+        metadata, errors = scanner.scan(path)
+        assert any(e.code == ErrorCode.E_SECURITY_INVALID_PDF for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# File Size Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFileSize:
+    def test_oversized_file(self, tmp_path):
+        # Config with tiny limit to avoid generating actual large files
+        config = PDFProcessorConfig(max_file_size_mb=0)
+        scanner = PDFSecurityScanner(config)
+        path = _write_pdf(tmp_path, _make_simple_pdf())
+        _, errors = scanner.scan(path)
+        assert any(e.code == ErrorCode.E_SECURITY_TOO_LARGE for e in errors)
+
+    def test_oversized_with_override(self, tmp_path):
+        config = PDFProcessorConfig(
+            max_file_size_mb=0,
+            max_file_size_override_reason="TICKET-100: test override",
+        )
+        scanner = PDFSecurityScanner(config)
+        path = _write_pdf(tmp_path, _make_simple_pdf())
+        _, errors = scanner.scan(path)
+        # Should NOT have fatal error
+        fatal = [e for e in errors if e.code == ErrorCode.E_SECURITY_TOO_LARGE]
+        assert len(fatal) == 0
+        # Should have warning
+        overrides = [e for e in errors if e.code == ErrorCode.W_SECURITY_OVERRIDE]
+        assert len(overrides) >= 1
+        assert "TICKET-100" in overrides[0].message
+
+
+# ---------------------------------------------------------------------------
+# Page Count Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPageCount:
+    def test_too_many_pages(self, tmp_path):
+        config = PDFProcessorConfig(max_page_count=2)
+        scanner = PDFSecurityScanner(config)
+        path = _write_pdf(tmp_path, _make_simple_pdf(num_pages=5))
+        _, errors = scanner.scan(path)
+        assert any(e.code == ErrorCode.E_SECURITY_TOO_MANY_PAGES for e in errors)
+
+    def test_page_count_at_limit(self, tmp_path):
+        config = PDFProcessorConfig(max_page_count=5)
+        scanner = PDFSecurityScanner(config)
+        path = _write_pdf(tmp_path, _make_simple_pdf(num_pages=5))
+        _, errors = scanner.scan(path)
+        fatal = [e for e in errors if e.code == ErrorCode.E_SECURITY_TOO_MANY_PAGES]
+        assert len(fatal) == 0
+
+    def test_page_count_override(self, tmp_path):
+        config = PDFProcessorConfig(
+            max_page_count=2,
+            max_page_count_override_reason="TICKET-200: large doc set",
+        )
+        scanner = PDFSecurityScanner(config)
+        path = _write_pdf(tmp_path, _make_simple_pdf(num_pages=5))
+        _, errors = scanner.scan(path)
+        fatal = [e for e in errors if e.code == ErrorCode.E_SECURITY_TOO_MANY_PAGES]
+        assert len(fatal) == 0
+        overrides = [e for e in errors if e.code == ErrorCode.W_SECURITY_OVERRIDE]
+        assert len(overrides) >= 1
+
+    def test_zero_pages(self, tmp_path):
+        """PDF with zero pages should fail with E_PARSE_EMPTY."""
+        # Craft a minimal valid PDF with zero pages (PyMuPDF refuses to save one)
+        minimal_pdf = (
+            b"%PDF-1.0\n"
+            b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+            b"2 0 obj<</Type/Pages/Kids[]/Count 0>>endobj\n"
+            b"xref\n0 3\n"
+            b"0000000000 65535 f \n"
+            b"0000000009 00000 n \n"
+            b"0000000058 00000 n \n"
+            b"trailer<</Size 3/Root 1 0 R>>\n"
+            b"startxref\n109\n%%EOF\n"
+        )
+        path = _write_pdf(tmp_path, minimal_pdf, name="zero.pdf")
+        scanner = PDFSecurityScanner(PDFProcessorConfig())
+        _, errors = scanner.scan(path)
+        assert any(e.code == ErrorCode.E_PARSE_EMPTY for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# JavaScript Detection Tests
+# ---------------------------------------------------------------------------
+
+
+class TestJavaScript:
+    @staticmethod
+    def _make_js_pdf(tmp_path) -> str:
+        """Create a PDF with embedded JavaScript using PyMuPDF xref API."""
+        path = str(tmp_path / "js.pdf")
+        doc = fitz.open()
+        doc.new_page()
+        doc.save(path)
+        doc.close()
+
+        # Re-open and inject JS via xref manipulation
+        doc = fitz.open(path)
+        js_code = "app.alert('test');"
+        xref = doc.get_new_xref()
+        doc.update_object(xref, f"<< /Type /Action /S /JavaScript /JS ({js_code}) >>")
+        catalog_xref = doc.pdf_catalog()
+        doc.xref_set_key(catalog_xref, "OpenAction", f"{xref} 0 R")
+        doc.saveIncr()
+        doc.close()
+        return path
+
+    def test_javascript_detected_and_rejected(self, tmp_path):
+        path = self._make_js_pdf(tmp_path)
+        scanner = PDFSecurityScanner(PDFProcessorConfig())
+        _, errors = scanner.scan(path)
+        assert any(e.code == ErrorCode.E_SECURITY_JAVASCRIPT for e in errors)
+
+    def test_javascript_with_override(self, tmp_path):
+        path = self._make_js_pdf(tmp_path)
+        config = PDFProcessorConfig(
+            reject_javascript=False,
+            reject_javascript_override_reason="TICKET-300: Legacy HR forms",
+        )
+        scanner = PDFSecurityScanner(config)
+        _, errors = scanner.scan(path)
+        fatal = [e for e in errors if e.code == ErrorCode.E_SECURITY_JAVASCRIPT]
+        assert len(fatal) == 0
+        overrides = [e for e in errors if e.code == ErrorCode.W_SECURITY_OVERRIDE]
+        assert len(overrides) >= 1
+        assert "TICKET-300" in overrides[0].message
+
+
+# ---------------------------------------------------------------------------
+# Encryption Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEncryption:
+    @staticmethod
+    def _make_encrypted_pdf(tmp_path, user_password: str, owner_password: str) -> str:
+        """Create an encrypted PDF using PyMuPDF."""
+        path = str(tmp_path / "encrypted.pdf")
+        doc = fitz.open()
+        doc.new_page()
+        page = doc[0]
+        tw = fitz.TextWriter(page.rect)
+        tw.append((100, 700), "Encrypted content")
+        tw.write_text(page)
+        perm = fitz.PDF_PERM_ACCESSIBILITY | fitz.PDF_PERM_PRINT
+        encrypt_meth = fitz.PDF_ENCRYPT_AES_256
+        doc.save(
+            path,
+            encryption=encrypt_meth,
+            user_pw=user_password,
+            owner_pw=owner_password,
+            permissions=perm,
+        )
+        doc.close()
+        return path
+
+    def test_owner_password_only(self, tmp_path):
+        """PDF with owner password but empty user password should be accessible."""
+        path = self._make_encrypted_pdf(tmp_path, user_password="", owner_password="secret")
+        scanner = PDFSecurityScanner(PDFProcessorConfig())
+        metadata, errors = scanner.scan(path)
+        # Should authenticate with empty password
+        fatal = [e for e in errors if e.code == ErrorCode.E_PARSE_PASSWORD]
+        assert len(fatal) == 0
+        assert metadata.is_encrypted is True
+
+    def test_user_password_required(self, tmp_path):
+        """PDF requiring user password should fail."""
+        path = self._make_encrypted_pdf(tmp_path, user_password="pass123", owner_password="owner456")
+        scanner = PDFSecurityScanner(PDFProcessorConfig())
+        metadata, errors = scanner.scan(path)
+        assert any(e.code == ErrorCode.E_PARSE_PASSWORD for e in errors)
+        assert metadata.needs_password is True
+
+
+# ---------------------------------------------------------------------------
+# Embedded Files Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddedFiles:
+    def test_embedded_files_warning(self, tmp_path):
+        """PDF with embedded files should produce W_EMBEDDED_FILES."""
+        path = str(tmp_path / "embed.pdf")
+        doc = fitz.open()
+        doc.new_page()
+        # Embed a file
+        doc.embfile_add("test.txt", b"embedded content", filename="test.txt")
+        doc.save(path)
+        doc.close()
+
+        scanner = PDFSecurityScanner(PDFProcessorConfig())
+        _, errors = scanner.scan(path)
+        assert any(e.code == ErrorCode.W_EMBEDDED_FILES for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Audit Logging Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAuditLogging:
+    def test_override_logged(self, tmp_path, caplog):
+        """Security overrides should emit WARNING log entries."""
+        config = PDFProcessorConfig(
+            max_file_size_mb=0,
+            max_file_size_override_reason="TICKET-400: test",
+        )
+        scanner = PDFSecurityScanner(config)
+        path = _write_pdf(tmp_path, _make_simple_pdf())
+        with caplog.at_level("WARNING", logger="ingestkit_pdf"):
+            scanner.scan(path)
+        assert any("SECURITY_OVERRIDE" in r.message for r in caplog.records)
+        assert any("TICKET-400" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_nonexistent_file(self, scanner):
+        """Non-existent file path should return E_SECURITY_INVALID_PDF."""
+        _, errors = scanner.scan("/nonexistent/file.pdf")
+        assert any(
+            e.code in (ErrorCode.E_SECURITY_INVALID_PDF, ErrorCode.E_PARSE_CORRUPT)
+            for e in errors
+        )
+
+    def test_errors_have_stage(self, scanner, tmp_path):
+        """All errors should have stage='security'."""
+        path = _write_pdf(tmp_path, b"NOT PDF", name="bad.pdf")
+        _, errors = scanner.scan(path)
+        for e in errors:
+            assert e.stage == "security"
+
+    def test_warnings_are_recoverable(self, scanner, tmp_path):
+        """All W_* warnings should have recoverable=True."""
+        # Create PDF with embedded files to trigger a warning
+        path = str(tmp_path / "warn.pdf")
+        doc = fitz.open()
+        doc.new_page()
+        doc.embfile_add("test.txt", b"data", filename="test.txt")
+        doc.save(path)
+        doc.close()
+
+        _, errors = scanner.scan(path)
+        for e in errors:
+            if e.code.value.startswith("W_"):
+                assert e.recoverable is True, f"{e.code} should be recoverable"


### PR DESCRIPTION
## What
PDFSecurityScanner: pre-flight validation that rejects dangerous/oversized PDFs before extraction.

## Why
First line of defense for compliance-sensitive deployments. Prevents processing of malicious PDFs (JS injection, decompression bombs, encrypted files).

Closes #26

## How
- Magic bytes check (%PDF- header)
- File size and page count enforcement with override governance
- JavaScript detection via PyMuPDF xref object scanning
- Decompression bomb detection (excessive xref objects)
- Encryption handling: attempts empty-password auth before rejecting
- Signed PDF and embedded files detection (warnings)
- Security override audit logging at WARNING level
- All test PDFs generated programmatically via reportlab/PyMuPDF (no binary fixtures)

## Stack
- [x] Backend

## Verification
- [x] `ruff check .` passes
- [x] `pytest tests/test_security.py -q` passes (21 tests)
- [x] Full PDF suite: 173 tests pass

## How to Test
1. `cd packages/ingestkit-pdf && .venv/bin/pytest tests/test_security.py -q`

## Risks / Rollback
Low risk — new module, no existing code modified.