### PR TITLE
feat(ingestkit-excel): Implement concrete backends — Qdrant, SQLite, Ollama + stubs (#11)

### DIFF
--- a/.agents/outputs/map-plan-11-021226.md
+++ b/.agents/outputs/map-plan-11-021226.md
@@ -1,0 +1,462 @@
+# MAP-PLAN — Issue #11: Concrete Backends
+
+## Executive Summary
+
+This issue implements the five concrete backend modules specified in SPEC.md section 12: `QdrantVectorStore` (vector store via `qdrant-client`), `SQLiteStructuredDB` (structured DB via `sqlite3` + pandas), `OllamaLLM` and `OllamaEmbedding` (LLM/embedding via Ollama HTTP API with `httpx`), plus two stub backends (`MilvusVectorStore`, `PostgresStructuredDB`). Each concrete backend must satisfy its corresponding `Protocol` from `ingestkit_core.protocols` using structural subtyping -- no inheritance from the protocols themselves. All backends live under `src/ingestkit_excel/backends/` and are covered by unit tests using mocks (no external services required).
+
+## Investigation Findings
+
+### Protocol Signatures (from `ingestkit_core/protocols.py`)
+
+**VectorStoreBackend:**
+```python
+def upsert_chunks(self, collection: str, chunks: list[ChunkPayload]) -> int
+def ensure_collection(self, collection: str, vector_size: int) -> None
+def create_payload_index(self, collection: str, field: str, field_type: str) -> None
+def delete_by_ids(self, collection: str, ids: list[str]) -> int
+```
+
+**StructuredDBBackend:**
+```python
+def create_table_from_dataframe(self, table_name: str, df: pd.DataFrame) -> None
+def drop_table(self, table_name: str) -> None
+def table_exists(self, table_name: str) -> bool
+def get_table_schema(self, table_name: str) -> dict
+def get_connection_uri(self) -> str
+```
+
+**LLMBackend:**
+```python
+def classify(self, prompt: str, model: str, temperature: float = 0.1, timeout: float | None = None) -> dict
+def generate(self, prompt: str, model: str, temperature: float = 0.7, timeout: float | None = None) -> str
+```
+
+**EmbeddingBackend:**
+```python
+def embed(self, texts: list[str], timeout: float | None = None) -> list[list[float]]
+def dimension(self) -> int
+```
+
+### Config Parameters (from `config.py`)
+
+| Parameter | Default | Used By |
+|-----------|---------|---------|
+| `backend_timeout_seconds` | 30.0 | All backends |
+| `backend_max_retries` | 2 | Qdrant, Ollama |
+| `backend_backoff_base` | 1.0 | Qdrant, Ollama |
+| `embedding_model` | `"nomic-embed-text"` | OllamaEmbedding |
+| `embedding_dimension` | 768 | OllamaEmbedding |
+| `embedding_batch_size` | 64 | OllamaEmbedding |
+| `default_collection` | `"helpdesk"` | QdrantVectorStore |
+| `classification_model` | `"qwen2.5:7b"` | OllamaLLM |
+
+### Error Codes (from `errors.py`)
+
+| Code | Used By |
+|------|---------|
+| `E_LLM_TIMEOUT` | OllamaLLM connection failure |
+| `E_LLM_MALFORMED_JSON` | OllamaLLM classify() parse failure |
+| `E_LLM_SCHEMA_INVALID` | OllamaLLM classify() schema validation failure |
+| `E_BACKEND_VECTOR_TIMEOUT` | QdrantVectorStore timeout |
+| `E_BACKEND_VECTOR_CONNECT` | QdrantVectorStore connection failure |
+| `E_BACKEND_DB_TIMEOUT` | SQLiteStructuredDB timeout |
+| `E_BACKEND_DB_CONNECT` | SQLiteStructuredDB connection failure |
+| `E_BACKEND_EMBED_TIMEOUT` | OllamaEmbedding timeout |
+| `E_BACKEND_EMBED_CONNECT` | OllamaEmbedding connection failure |
+
+### ChunkPayload Structure (from `ingestkit_core/models.py`)
+
+```python
+class ChunkPayload(BaseModel):
+    id: str
+    text: str
+    vector: list[float]
+    metadata: BaseChunkMetadata
+```
+
+`BaseChunkMetadata` fields: `source_uri`, `source_format`, `ingestion_method`, `parser_version`, `chunk_index`, `chunk_hash`, `ingest_key`, `ingest_run_id`, `tenant_id`, `table_name`, `row_count`, `columns`, `section_title`.
+
+### Dependencies (from `pyproject.toml`)
+
+- `qdrant-client>=1.7` -- optional dependency under `[qdrant]` extra
+- `httpx>=0.27` -- optional dependency under `[ollama]` extra
+- `sqlite3` -- stdlib, no extra needed
+- `pandas>=2.0` -- core dependency, already available
+
+### Existing Test Patterns
+
+Tests use class-based organization (`TestSomething`), mock backends as simple classes (not `MagicMock`), factory functions (`_make_*`) for test data, `@pytest.mark.unit` marker, `@patch` decorator for external calls, and `conftest.py` for shared fixtures.
+
+## Implementation Plan
+
+### File 1: `src/ingestkit_excel/backends/__init__.py`
+
+```python
+"""Concrete backend implementations for the ingestkit-excel pipeline.
+
+This package provides reference implementations of the four backend protocols:
+- QdrantVectorStore (VectorStoreBackend)
+- SQLiteStructuredDB (StructuredDBBackend)
+- OllamaLLM (LLMBackend)
+- OllamaEmbedding (EmbeddingBackend)
+
+Stub implementations (MilvusVectorStore, PostgresStructuredDB) raise
+NotImplementedError for all methods.
+"""
+
+from ingestkit_excel.backends.milvus import MilvusVectorStore
+from ingestkit_excel.backends.ollama import OllamaEmbedding, OllamaLLM
+from ingestkit_excel.backends.postgres import PostgresStructuredDB
+from ingestkit_excel.backends.qdrant import QdrantVectorStore
+from ingestkit_excel.backends.sqlite import SQLiteStructuredDB
+
+__all__ = [
+    "QdrantVectorStore",
+    "SQLiteStructuredDB",
+    "OllamaLLM",
+    "OllamaEmbedding",
+    "MilvusVectorStore",
+    "PostgresStructuredDB",
+]
+```
+
+### File 2: `src/ingestkit_excel/backends/qdrant.py` (QdrantVectorStore)
+
+**Class: `QdrantVectorStore`**
+
+Constructor parameters:
+- `url: str = "localhost"` -- Qdrant host
+- `port: int = 6333` -- Qdrant port
+- `timeout: float = 30.0` -- Default timeout (from config)
+- `max_retries: int = 2` -- Retry limit (from config)
+- `backoff_base: float = 1.0` -- Base for exponential backoff
+
+Internal state:
+- `self._client: QdrantClient` -- lazily or eagerly initialized
+
+Methods:
+
+1. **`ensure_collection(collection: str, vector_size: int) -> None`**
+   - Import `qdrant_client.models` for `Distance`, `VectorParams`
+   - Check if collection exists via `self._client.collection_exists(collection)`
+   - If not, create with `self._client.create_collection(collection, vectors_config=VectorParams(size=vector_size, distance=Distance.COSINE))`
+   - Wrap in `_with_retry()` helper
+
+2. **`upsert_chunks(collection: str, chunks: list[ChunkPayload]) -> int`**
+   - Convert each `ChunkPayload` to a `PointStruct(id=chunk.id, vector=chunk.vector, payload=chunk.metadata.model_dump())`
+   - Also add `"text": chunk.text` to the payload
+   - Call `self._client.upsert(collection_name=collection, points=points)`
+   - Return `len(chunks)`
+   - Wrap in `_with_retry()`
+
+3. **`create_payload_index(collection: str, field: str, field_type: str) -> None`**
+   - Map `field_type` string to `qdrant_client.models.PayloadSchemaType` (keyword, integer, etc.)
+   - Call `self._client.create_payload_index(collection_name=collection, field_name=field, field_schema=schema_type)`
+   - Wrap in `_with_retry()`
+
+4. **`delete_by_ids(collection: str, ids: list[str]) -> int`**
+   - Call `self._client.delete(collection_name=collection, points_selector=PointIdsList(points=ids))`
+   - Return `len(ids)`
+   - Wrap in `_with_retry()`
+
+5. **`_with_retry(fn, *args, **kwargs)`** (private helper)
+   - For i in range(max_retries + 1):
+     - Try fn(*args, **kwargs)
+     - On timeout/connection error: sleep `backoff_base * 2**i`, retry
+     - On last attempt: raise `IngestError` with `E_BACKEND_VECTOR_TIMEOUT` or `E_BACKEND_VECTOR_CONNECT`
+
+Import guard: wrap `import qdrant_client` in try/except, raise `ImportError` with install hint if missing.
+
+Logging: Use `logger = logging.getLogger("ingestkit_excel")`.
+
+### File 3: `src/ingestkit_excel/backends/sqlite.py` (SQLiteStructuredDB)
+
+**Class: `SQLiteStructuredDB`**
+
+Constructor parameters:
+- `db_path: str = ":memory:"` -- Path to SQLite file (or `:memory:`)
+
+Internal state:
+- `self._db_path: str`
+- `self._conn: sqlite3.Connection` -- eagerly connected in __init__
+
+Methods:
+
+1. **`create_table_from_dataframe(table_name: str, df: pd.DataFrame) -> None`**
+   - Call `df.to_sql(table_name, self._conn, if_exists="replace", index=False)`
+
+2. **`drop_table(table_name: str) -> None`**
+   - Execute `DROP TABLE IF EXISTS {table_name}` (with proper sanitization)
+
+3. **`table_exists(table_name: str) -> bool`**
+   - Execute `SELECT name FROM sqlite_master WHERE type='table' AND name=?`
+   - Return `bool(cursor.fetchone())`
+
+4. **`get_table_schema(table_name: str) -> dict`**
+   - Execute `PRAGMA table_info({table_name})`
+   - Return `{row[1]: row[2] for row in cursor.fetchall()}` (name: type)
+
+5. **`get_connection_uri(self) -> str`**
+   - Return `f"sqlite:///{self._db_path}"` (or `"sqlite://"` for `:memory:`)
+
+No retry logic needed for SQLite (local, no network). Add `close()` method for resource cleanup.
+
+### File 4: `src/ingestkit_excel/backends/ollama.py` (OllamaLLM + OllamaEmbedding)
+
+**Class: `OllamaLLM`**
+
+Constructor parameters:
+- `base_url: str = "http://localhost:11434"` -- Ollama API base URL
+- `timeout: float = 30.0` -- Default timeout
+- `max_retries: int = 2` -- Retry limit for connection failures
+- `backoff_base: float = 1.0` -- Base for exponential backoff
+
+Methods:
+
+1. **`classify(prompt: str, model: str, temperature: float = 0.1, timeout: float | None = None) -> dict`**
+   - POST to `{base_url}/api/generate` with `{"model": model, "prompt": prompt, "stream": false, "options": {"temperature": temperature}}`
+   - Timeout: `timeout or self._timeout`
+   - Parse JSON from `response["response"]` field
+   - On `json.JSONDecodeError`: retry once with a correction hint appended to prompt ("Please respond with valid JSON only.")
+   - On second failure: raise `IngestError` with `E_LLM_MALFORMED_JSON`
+   - On `httpx.TimeoutException`: raise `IngestError` with `E_LLM_TIMEOUT`
+   - On `httpx.ConnectError`: raise `IngestError` with `E_LLM_TIMEOUT`
+   - Return the parsed dict
+
+2. **`generate(prompt: str, model: str, temperature: float = 0.7, timeout: float | None = None) -> str`**
+   - POST to `{base_url}/api/generate` with `{"model": model, "prompt": prompt, "stream": false, "options": {"temperature": temperature}}`
+   - Return `response["response"]` as raw text
+   - On timeout/connect: raise `IngestError` with `E_LLM_TIMEOUT`
+
+3. **`_post(endpoint: str, payload: dict, timeout: float) -> dict`** (private)
+   - `httpx.post(self._base_url + endpoint, json=payload, timeout=timeout)`
+   - Return `response.json()`
+
+Import guard: wrap `import httpx` in try/except with install hint.
+
+**Class: `OllamaEmbedding`**
+
+Constructor parameters:
+- `model: str = "nomic-embed-text"` -- Embedding model name
+- `base_url: str = "http://localhost:11434"` -- Ollama API base URL
+- `timeout: float = 30.0` -- Default timeout
+- `vector_dimension: int = 768` -- Expected vector dimension
+
+Methods:
+
+1. **`embed(texts: list[str], timeout: float | None = None) -> list[list[float]]`**
+   - POST to `{base_url}/api/embed` with `{"model": self._model, "input": texts}`
+   - Timeout: `timeout or self._timeout`
+   - Return `response["embeddings"]`
+   - On timeout/connect: raise `IngestError` with `E_BACKEND_EMBED_TIMEOUT` or `E_BACKEND_EMBED_CONNECT`
+
+2. **`dimension(self) -> int`**
+   - Return `self._vector_dimension`
+
+Import guard: same httpx check as OllamaLLM (shared module).
+
+### File 5: `src/ingestkit_excel/backends/milvus.py` (MilvusVectorStore stub)
+
+```python
+"""Stub implementation of VectorStoreBackend for Milvus.
+
+To implement, see backends/qdrant.py for the reference VectorStoreBackend.
+"""
+
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ingestkit_core.models import ChunkPayload
+
+
+class MilvusVectorStore:
+    """Milvus vector store backend (not yet implemented)."""
+
+    def upsert_chunks(self, collection: str, chunks: list[ChunkPayload]) -> int:
+        raise NotImplementedError("MilvusVectorStore not yet implemented. See backends/qdrant.py for reference.")
+
+    def ensure_collection(self, collection: str, vector_size: int) -> None:
+        raise NotImplementedError("MilvusVectorStore not yet implemented. See backends/qdrant.py for reference.")
+
+    def create_payload_index(self, collection: str, field: str, field_type: str) -> None:
+        raise NotImplementedError("MilvusVectorStore not yet implemented. See backends/qdrant.py for reference.")
+
+    def delete_by_ids(self, collection: str, ids: list[str]) -> int:
+        raise NotImplementedError("MilvusVectorStore not yet implemented. See backends/qdrant.py for reference.")
+```
+
+### File 6: `src/ingestkit_excel/backends/postgres.py` (PostgresStructuredDB stub)
+
+```python
+"""Stub implementation of StructuredDBBackend for PostgreSQL.
+
+To implement, see backends/sqlite.py for the reference StructuredDBBackend.
+"""
+
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+class PostgresStructuredDB:
+    """PostgreSQL structured database backend (not yet implemented)."""
+
+    def create_table_from_dataframe(self, table_name: str, df: pd.DataFrame) -> None:
+        raise NotImplementedError("PostgresStructuredDB not yet implemented. See backends/sqlite.py for reference.")
+
+    def drop_table(self, table_name: str) -> None:
+        raise NotImplementedError("PostgresStructuredDB not yet implemented. See backends/sqlite.py for reference.")
+
+    def table_exists(self, table_name: str) -> bool:
+        raise NotImplementedError("PostgresStructuredDB not yet implemented. See backends/sqlite.py for reference.")
+
+    def get_table_schema(self, table_name: str) -> dict:
+        raise NotImplementedError("PostgresStructuredDB not yet implemented. See backends/sqlite.py for reference.")
+
+    def get_connection_uri(self) -> str:
+        raise NotImplementedError("PostgresStructuredDB not yet implemented. See backends/sqlite.py for reference.")
+```
+
+### File 7: `tests/test_backends.py`
+
+**Test Organization:**
+
+```
+class TestSQLiteStructuredDB:
+    # Tests using real sqlite3 (in-memory) -- no mocking needed
+    test_create_table_from_dataframe_basic
+    test_create_table_from_dataframe_replace_existing
+    test_drop_table
+    test_drop_table_nonexistent_no_error
+    test_table_exists_true
+    test_table_exists_false
+    test_get_table_schema_returns_column_types
+    test_get_connection_uri_file
+    test_get_connection_uri_memory
+    test_protocol_conformance  # isinstance(db, StructuredDBBackend)
+
+class TestQdrantVectorStore:
+    # Tests using mock qdrant_client.QdrantClient
+    test_ensure_collection_creates_when_missing
+    test_ensure_collection_skips_when_exists
+    test_upsert_chunks_converts_to_points
+    test_upsert_chunks_returns_count
+    test_upsert_chunks_includes_text_in_payload
+    test_create_payload_index_keyword
+    test_create_payload_index_integer
+    test_delete_by_ids_returns_count
+    test_retry_on_timeout
+    test_retry_exhausted_raises_error
+    test_protocol_conformance  # isinstance(store, VectorStoreBackend)
+
+class TestOllamaLLM:
+    # Tests using mock httpx responses
+    test_classify_valid_json_response
+    test_classify_retries_on_malformed_json
+    test_classify_raises_after_second_malformed_json
+    test_classify_timeout_raises_error
+    test_classify_connect_error_raises
+    test_generate_returns_raw_text
+    test_generate_timeout_raises_error
+    test_protocol_conformance  # isinstance(llm, LLMBackend)
+
+class TestOllamaEmbedding:
+    # Tests using mock httpx responses
+    test_embed_returns_vectors
+    test_embed_batch_of_texts
+    test_embed_timeout_raises_error
+    test_embed_connect_error_raises
+    test_dimension_returns_configured_value
+    test_protocol_conformance  # isinstance(emb, EmbeddingBackend)
+
+class TestMilvusVectorStoreStub:
+    test_all_methods_raise_not_implemented
+    test_protocol_conformance  # isinstance(store, VectorStoreBackend)
+
+class TestPostgresStructuredDBStub:
+    test_all_methods_raise_not_implemented
+    test_protocol_conformance  # isinstance(db, StructuredDBBackend)
+```
+
+**Key testing patterns:**
+- SQLite tests use real in-memory SQLite (no mocking -- it is a stdlib module)
+- Qdrant tests mock `qdrant_client.QdrantClient` using `unittest.mock.patch`
+- Ollama tests mock `httpx.Client.post` or use `unittest.mock.patch` on the `_post` helper
+- All protocol conformance tests use `isinstance` checks against the `@runtime_checkable` protocols
+- All test classes marked with `@pytest.mark.unit`
+- Factory helpers for `ChunkPayload` test data
+
+### File 8: `__init__.py` Updates
+
+Add backend imports to `src/ingestkit_excel/__init__.py`:
+
+```python
+# Add after existing imports:
+from ingestkit_excel.backends import (
+    MilvusVectorStore,
+    OllamaEmbedding,
+    OllamaLLM,
+    PostgresStructuredDB,
+    QdrantVectorStore,
+    SQLiteStructuredDB,
+)
+
+# Add to __all__:
+    # Backends
+    "QdrantVectorStore",
+    "SQLiteStructuredDB",
+    "OllamaLLM",
+    "OllamaEmbedding",
+    "MilvusVectorStore",
+    "PostgresStructuredDB",
+```
+
+## Acceptance Criteria
+
+- [ ] `backends/__init__.py` exports all 6 backend classes
+- [ ] `QdrantVectorStore` implements all 4 `VectorStoreBackend` methods with retry/backoff
+- [ ] `SQLiteStructuredDB` implements all 5 `StructuredDBBackend` methods using sqlite3 + pandas
+- [ ] `OllamaLLM` implements `classify` (with JSON retry) and `generate` using httpx
+- [ ] `OllamaEmbedding` implements `embed` and `dimension` using httpx
+- [ ] `MilvusVectorStore` raises `NotImplementedError` for all methods
+- [ ] `PostgresStructuredDB` raises `NotImplementedError` for all methods
+- [ ] All backends pass `isinstance` checks against their respective `@runtime_checkable` protocols
+- [ ] All backends use proper error codes from `errors.py` on failure
+- [ ] Qdrant and Ollama backends have import guards with helpful error messages
+- [ ] Unit tests cover all public methods with no external service dependencies
+- [ ] Package-level `__init__.py` exports all backend classes
+- [ ] All existing tests still pass (no regressions)
+- [ ] Logger name is `ingestkit_excel` (PII-safe logging)
+
+## Verification Gates
+
+```bash
+# 1. Run only the new backend tests
+pytest packages/ingestkit-excel/tests/test_backends.py -v -m unit
+
+# 2. Run full test suite to check for regressions
+pytest packages/ingestkit-excel/tests -v
+
+# 3. Verify protocol conformance (in test suite)
+# isinstance checks are embedded in test_backends.py
+
+# 4. Verify imports work
+python -c "from ingestkit_excel.backends import QdrantVectorStore, SQLiteStructuredDB, OllamaLLM, OllamaEmbedding, MilvusVectorStore, PostgresStructuredDB; print('All imports OK')"
+
+# 5. Verify package-level exports
+python -c "from ingestkit_excel import QdrantVectorStore, SQLiteStructuredDB, OllamaLLM, OllamaEmbedding; print('Package exports OK')"
+```
+
+## Implementation Order
+
+1. `backends/__init__.py` (empty initially, fill as files are created)
+2. `backends/sqlite.py` (simplest -- no optional deps, real sqlite3 for testing)
+3. `backends/qdrant.py` (optional dep, mocked in tests)
+4. `backends/ollama.py` (optional dep, mocked in tests)
+5. `backends/milvus.py` (stub)
+6. `backends/postgres.py` (stub)
+7. `tests/test_backends.py` (all test classes)
+8. Update `__init__.py` for package-level exports

--- a/.agents/outputs/patch-11-021226.md
+++ b/.agents/outputs/patch-11-021226.md
@@ -1,0 +1,92 @@
+# Patch Output: Issue #11 -- Concrete Backends
+
+**Issue:** [Spec] Implement concrete backends: Qdrant, SQLite, Ollama + stubs
+**Branch:** feature/issue-11-concrete-backends
+**Date:** 2026-02-12
+
+## Summary
+
+Implemented 6 concrete backend classes across 7 new files, plus a comprehensive test suite (66 tests). All backends conform to the 4 Protocol interfaces defined in `ingestkit_core.protocols`. Full regression suite passes (513 tests, 0 failures).
+
+## Files Created
+
+### 1. `packages/ingestkit-excel/src/ingestkit_excel/backends/__init__.py`
+- Package init with lazy imports using try/except ImportError guards
+- Exports all 6 backend classes: `SQLiteStructuredDB`, `QdrantVectorStore`, `OllamaLLM`, `OllamaEmbedding`, `MilvusVectorStore`, `PostgresStructuredDB`
+- Optional-dep backends (`QdrantVectorStore`, `OllamaLLM`, `OllamaEmbedding`) gracefully fall back to `None` when deps missing
+
+### 2. `packages/ingestkit-excel/src/ingestkit_excel/backends/sqlite.py`
+- `SQLiteStructuredDB` -- satisfies `StructuredDBBackend` protocol
+- Uses stdlib `sqlite3` (no external deps)
+- Methods: `create_table_from_dataframe`, `drop_table`, `table_exists`, `get_table_schema`, `get_connection_uri`, `close`
+- Uses `df.to_sql()` with `if_exists='replace'`
+- Schema via `PRAGMA table_info`
+
+### 3. `packages/ingestkit-excel/src/ingestkit_excel/backends/qdrant.py`
+- `QdrantVectorStore` -- satisfies `VectorStoreBackend` protocol
+- Lazy import of `qdrant_client` (optional dep)
+- Methods: `ensure_collection`, `upsert_chunks`, `create_payload_index`, `delete_by_ids`
+- Collection prefix support for multi-tenant isolation
+- Exponential backoff retry via `config.backend_max_retries` and `config.backend_backoff_base`
+- Converts `ChunkPayload` to Qdrant `PointStruct` format
+- Cosine distance for collections
+
+### 4. `packages/ingestkit-excel/src/ingestkit_excel/backends/ollama.py`
+- `OllamaLLM` -- satisfies `LLMBackend` protocol
+  - `classify()` -- POST /api/generate with format=json, JSON parse with 1 retry on malformed
+  - `generate()` -- POST /api/generate, return raw text
+  - Retry with backoff on timeout/connection errors
+  - Raises `TimeoutError` / `ConnectionError` (compatible with processor error classification)
+- `OllamaEmbedding` -- satisfies `EmbeddingBackend` protocol
+  - `embed()` -- POST /api/embed, return vectors
+  - `dimension()` -- return configured dimension
+  - Retry with backoff on timeout/connection errors
+
+### 5. `packages/ingestkit-excel/src/ingestkit_excel/backends/milvus.py`
+- `MilvusVectorStore` stub -- all methods raise `NotImplementedError`
+- Satisfies `VectorStoreBackend` protocol shape for isinstance checks
+
+### 6. `packages/ingestkit-excel/src/ingestkit_excel/backends/postgres.py`
+- `PostgresStructuredDB` stub -- all methods raise `NotImplementedError`
+- Satisfies `StructuredDBBackend` protocol shape for isinstance checks
+
+### 7. `packages/ingestkit-excel/tests/test_backends.py`
+- 66 unit tests across 7 test classes:
+  - `TestSQLiteStructuredDB` (12 tests) -- real in-memory SQLite
+  - `TestQdrantVectorStore` (15 tests) -- mocked qdrant_client
+  - `TestOllamaLLM` (10 tests) -- mocked httpx
+  - `TestOllamaEmbedding` (9 tests) -- mocked httpx
+  - `TestStubs` (9 tests) -- NotImplementedError verification
+  - `TestProtocolConformance` (6 tests) -- isinstance checks
+  - `TestBackendsPackageImport` (5 tests) -- import verification
+
+## Files Modified
+
+### 8. `packages/ingestkit-excel/src/ingestkit_excel/__init__.py`
+- Added backend imports from `ingestkit_excel.backends`
+- Added 6 backend classes to `__all__`
+
+## Design Decisions
+
+1. **Standard exceptions, not IngestError**: Backends raise `ConnectionError`, `TimeoutError`, `json.JSONDecodeError`, and `RuntimeError` instead of `IngestError` (which is a Pydantic BaseModel, not an Exception). This is consistent with how existing processors catch and classify backend errors via `_classify_backend_error()`.
+
+2. **Exception messages include keywords**: Error messages include terms like "vector", "qdrant", "connection", "timed out", "embed" so that the processor's `_classify_backend_error()` method can correctly map them to error codes.
+
+3. **Retry is internal to backends**: The retry-with-backoff logic lives inside each backend method, using `config.backend_max_retries` and `config.backend_backoff_base`. After retries are exhausted, a standard Python exception propagates to the caller.
+
+4. **classify() JSON retry**: `OllamaLLM.classify()` has its own 1-retry for malformed JSON (separate from HTTP retries), consistent with the LLM classifier's retry pattern.
+
+## Verification
+
+```
+$ pytest packages/ingestkit-excel/tests/test_backends.py -v
+66 passed in 0.77s
+
+$ pytest packages/ingestkit-excel/tests -v
+513 passed in 1.33s
+
+$ python3 -c "from ingestkit_excel.backends import QdrantVectorStore, SQLiteStructuredDB, OllamaLLM, OllamaEmbedding; print('OK')"
+OK
+```
+
+AGENT_RETURN: patch-11-021226.md

--- a/.agents/outputs/plan-check-11-021226.md
+++ b/.agents/outputs/plan-check-11-021226.md
@@ -1,0 +1,118 @@
+---
+issue: 11
+agent: PLAN-CHECK
+date: 2026-02-12
+plan_artifact: map-plan-11-021226.md
+status: PASS
+---
+
+# PLAN-CHECK — Issue #11: Concrete Backends
+
+## Executive Summary
+
+The MAP-PLAN artifact for issue #11 is **well-formed and complete**. All issue requirements map to plan sections. Protocol signatures match the authoritative source exactly. Scope is correctly contained to `backends/` files, tests, and `__init__.py` exports. The `backends/` directory does not yet exist, confirming a clean starting point. Two minor findings noted below — neither is blocking.
+
+## Check 1: Requirement Coverage
+
+| Issue Requirement | Plan Section | Status |
+|---|---|---|
+| **QdrantVectorStore** | File 2: `backends/qdrant.py` | |
+| `ensure_collection` (cosine, create if not exists) | Method 1 — creates with `Distance.COSINE` | ✅ |
+| `upsert_chunks` (batch points with metadata) | Method 2 — converts to `PointStruct`, includes text in payload | ✅ |
+| `create_payload_index` (keyword/integer) | Method 3 — maps `field_type` to `PayloadSchemaType` | ✅ |
+| `delete_by_ids` | Method 4 — `PointIdsList` selector | ✅ |
+| Timeout + retry with exponential backoff | Method 5 (`_with_retry`) + constructor params from config | ✅ |
+| **SQLiteStructuredDB** | File 3: `backends/sqlite.py` | |
+| `create_table_from_dataframe` (replace if exists) | Method 1 — `df.to_sql(if_exists="replace")` | ✅ |
+| `drop_table` | Method 2 — `DROP TABLE IF EXISTS` | ✅ |
+| `table_exists` (check `sqlite_master`) | Method 3 — `SELECT FROM sqlite_master` | ✅ |
+| `get_table_schema` (`PRAGMA table_info`) | Method 4 — returns `{name: type}` dict | ✅ |
+| `get_connection_uri` | Method 5 — `sqlite:///path` or `sqlite://` for memory | ✅ |
+| **OllamaLLM** | File 4: `backends/ollama.py` | |
+| `classify` (JSON parse + retry on malformed) | Method 1 — retry once with correction hint, `E_LLM_MALFORMED_JSON` | ✅ |
+| `generate` (raw text) | Method 2 — returns `response["response"]` | ✅ |
+| Timeout → `E_LLM_TIMEOUT` | Both methods handle `httpx.TimeoutException` | ✅ |
+| **OllamaEmbedding** | File 4: `backends/ollama.py` | |
+| `embed` (batch, float vectors, timeout) | Method 1 — `POST /api/embed` | ✅ |
+| `dimension` (768 default) | Method 2 — returns `self._vector_dimension` | ✅ |
+| **Stubs** | Files 5-6 | |
+| `MilvusVectorStore` → `NotImplementedError` | File 5 — all 4 methods raise with message | ✅ |
+| `PostgresStructuredDB` → `NotImplementedError` | File 6 — all 5 methods raise with message | ✅ |
+| Module-level docstrings explaining how to implement | Both stubs have docstrings referencing the concrete impl | ✅ |
+
+**Coverage: 20/20 requirements mapped.** No gaps.
+
+## Check 2: Scope Containment
+
+| Scope Rule | Status |
+|---|---|
+| Only creates files under `backends/` | ✅ 5 new files in `src/ingestkit_excel/backends/` |
+| Only creates `tests/test_backends.py` | ✅ Single test file |
+| Updates only `__init__.py` exports | ✅ File 8 adds imports + `__all__` entries |
+| No changes to core processing (`parser_chain`, `inspector`, `llm_classifier`, `processors`) | ✅ Not touched |
+| No changes to `protocols.py`, `models.py`, `config.py`, `errors.py` | ✅ Not touched |
+| No ABC base classes introduced | ✅ All backends are concrete classes, no inheritance from protocols |
+
+**Scope: Clean.** No overreach detected.
+
+## Check 3: Protocol Signature Match
+
+Compared plan's method signatures against the authoritative source at `/home/jjob/projects/ingestkit/packages/ingestkit-core/src/ingestkit_core/protocols.py`:
+
+| Protocol | Method | Plan Signature | Actual Signature | Match |
+|---|---|---|---|---|
+| VectorStoreBackend | `upsert_chunks` | `(self, collection: str, chunks: list[ChunkPayload]) -> int` | `(self, collection: str, chunks: list[ChunkPayload]) -> int` | ✅ |
+| VectorStoreBackend | `ensure_collection` | `(self, collection: str, vector_size: int) -> None` | `(self, collection: str, vector_size: int) -> None` | ✅ |
+| VectorStoreBackend | `create_payload_index` | `(self, collection: str, field: str, field_type: str) -> None` | `(self, collection: str, field: str, field_type: str) -> None` | ✅ |
+| VectorStoreBackend | `delete_by_ids` | `(self, collection: str, ids: list[str]) -> int` | `(self, collection: str, ids: list[str]) -> int` | ✅ |
+| StructuredDBBackend | `create_table_from_dataframe` | `(self, table_name: str, df: pd.DataFrame) -> None` | `(self, table_name: str, df: pd.DataFrame) -> None` | ✅ |
+| StructuredDBBackend | `drop_table` | `(self, table_name: str) -> None` | `(self, table_name: str) -> None` | ✅ |
+| StructuredDBBackend | `table_exists` | `(self, table_name: str) -> bool` | `(self, table_name: str) -> bool` | ✅ |
+| StructuredDBBackend | `get_table_schema` | `(self, table_name: str) -> dict` | `(self, table_name: str) -> dict` | ✅ |
+| StructuredDBBackend | `get_connection_uri` | `(self) -> str` | `(self) -> str` | ✅ |
+| LLMBackend | `classify` | `(self, prompt: str, model: str, temperature: float = 0.1, timeout: float \| None = None) -> dict` | `(self, prompt: str, model: str, temperature: float = 0.1, timeout: float \| None = None) -> dict` | ✅ |
+| LLMBackend | `generate` | `(self, prompt: str, model: str, temperature: float = 0.7, timeout: float \| None = None) -> str` | `(self, prompt: str, model: str, temperature: float = 0.7, timeout: float \| None = None) -> str` | ✅ |
+| EmbeddingBackend | `embed` | `(self, texts: list[str], timeout: float \| None = None) -> list[list[float]]` | `(self, texts: list[str], timeout: float \| None = None) -> list[list[float]]` | ✅ |
+| EmbeddingBackend | `dimension` | `(self) -> int` | `(self) -> int` | ✅ |
+
+**All 13 method signatures match exactly.**
+
+## Check 4: Wiring
+
+| Item | Status | Detail |
+|---|---|---|
+| `backends/` directory does not exist yet | ✅ Confirmed: `ls` returns "No such file or directory" |
+| Current `__init__.py` exports | ✅ Reviewed — no backend imports present; plan adds them cleanly |
+| `backends/__init__.py` imports all 6 classes | ✅ Plan File 1 shows complete `__all__` |
+| Package `__init__.py` re-exports all 6 | ✅ Plan File 8 adds imports + `__all__` entries |
+| Protocols re-exported from `ingestkit_excel.protocols` | ✅ Already in place (re-exports from `ingestkit_core.protocols`) |
+
+## Check 5: ChunkPayload Model Reference
+
+The plan references `ChunkPayload` with fields `id`, `text`, `vector`, `metadata` (of type `BaseChunkMetadata`). Verified against `/home/jjob/projects/ingestkit/packages/ingestkit-core/src/ingestkit_core/models.py`:
+- `ChunkPayload.id: str` ✅
+- `ChunkPayload.text: str` ✅
+- `ChunkPayload.vector: list[float]` ✅
+- `ChunkPayload.metadata: BaseChunkMetadata` ✅
+
+Plan's `upsert_chunks` correctly accesses `chunk.metadata.model_dump()` and adds `chunk.text` to the Qdrant payload. This is consistent.
+
+## Findings
+
+### Finding 1 (MINOR): `backends/__init__.py` eager imports may fail without optional deps
+
+The plan's `backends/__init__.py` (File 1) unconditionally imports from `qdrant.py` and `ollama.py`. If `qdrant-client` or `httpx` are not installed, `from ingestkit_excel.backends import SQLiteStructuredDB` will fail even though SQLite has no optional deps.
+
+**Recommendation for PATCH**: Use lazy imports or conditional imports in `backends/__init__.py`. Alternatively, the import guards inside `qdrant.py` and `ollama.py` should raise `ImportError` only when the class is *instantiated*, not when the module is *imported*. The plan already mentions import guards but places them at module level — PATCH should ensure the guard fires in `__init__` (constructor), not at import time.
+
+**Severity**: Minor — does not block plan acceptance but PATCH should handle it.
+
+### Finding 2 (MINOR): `E_LLM_SCHEMA_INVALID` listed in error codes table but not used
+
+The plan's error codes table (line 59) lists `E_LLM_SCHEMA_INVALID` but no method in the plan raises it. The issue mentions "validate against schema" for `classify`. This is actually fine — schema validation is done by `LLMClassifier` (a higher-level component), not by the backend itself. The backend `classify` only parses JSON. No action needed.
+
+## Verdict
+
+**PASS** — The plan is complete, correctly scoped, and protocol-accurate. Ready for PATCH.
+
+AGENT_RETURN: plan-check-11-021226.md

--- a/.agents/outputs/prove-11-021226.md
+++ b/.agents/outputs/prove-11-021226.md
@@ -1,0 +1,182 @@
+# PROVE: Issue #11 -- Concrete Backends
+
+**Date:** 2026-02-12
+**Branch:** `feature/issue-8-path-a-processor`
+**Verdict:** PASS
+
+---
+
+## Level 1: Tests
+
+### Backend tests (`test_backends.py`)
+
+```
+66 collected, 66 passed in 0.73s
+```
+
+All 66 tests pass. Breakdown by class:
+
+| Test Class | Count | Status |
+|---|---|---|
+| TestSQLiteStructuredDB | 12 | PASS |
+| TestQdrantVectorStore | 15 | PASS |
+| TestOllamaLLM | 10 | PASS |
+| TestOllamaEmbedding | 9 | PASS |
+| TestStubs | 9 | PASS |
+| TestProtocolConformance | 6 | PASS |
+| TestBackendsPackageImport | 5 | PASS |
+
+### Full test suite
+
+```
+513 collected, 513 passed in 1.39s
+```
+
+Zero regressions. All pre-existing tests continue to pass.
+
+---
+
+## Level 2: Imports
+
+All six backend classes import successfully from the `ingestkit_excel.backends` package:
+
+| Class | Import Result |
+|---|---|
+| `SQLiteStructuredDB` | OK -- class loaded |
+| `QdrantVectorStore` | OK -- `<class 'ingestkit_excel.backends.qdrant.QdrantVectorStore'>` |
+| `OllamaLLM` | OK -- `<class 'ingestkit_excel.backends.ollama.OllamaLLM'>` |
+| `OllamaEmbedding` | OK -- `<class 'ingestkit_excel.backends.ollama.OllamaEmbedding'>` |
+| `MilvusVectorStore` | OK -- `<class 'ingestkit_excel.backends.milvus.MilvusVectorStore'>` |
+| `PostgresStructuredDB` | OK -- `<class 'ingestkit_excel.backends.postgres.PostgresStructuredDB'>` |
+
+Lazy import guards in `__init__.py` verified: `QdrantVectorStore`, `OllamaLLM`, `OllamaEmbedding` are wrapped in `try/except ImportError` blocks. When optional deps are missing, they default to `None` without breaking the package import.
+
+---
+
+## Level 3: Protocol Conformance
+
+All six backends satisfy their respective `@runtime_checkable` Protocol via `isinstance()`:
+
+```
+SQLite satisfies StructuredDBBackend: True
+Qdrant satisfies VectorStoreBackend: True
+OllamaLLM satisfies LLMBackend: True
+OllamaEmbedding satisfies EmbeddingBackend: True
+MilvusVectorStore satisfies VectorStoreBackend: True
+PostgresStructuredDB satisfies StructuredDBBackend: True
+```
+
+No ABC usage found. No explicit Protocol inheritance. Purely structural subtyping as required by project constraints.
+
+### Protocol method coverage
+
+| Protocol | Methods | Backend | Implemented |
+|---|---|---|---|
+| `StructuredDBBackend` | create_table_from_dataframe, drop_table, table_exists, get_table_schema, get_connection_uri | `SQLiteStructuredDB` | All 5 |
+| `StructuredDBBackend` | (same 5) | `PostgresStructuredDB` (stub) | All 5 (raise NotImplementedError) |
+| `VectorStoreBackend` | upsert_chunks, ensure_collection, create_payload_index, delete_by_ids | `QdrantVectorStore` | All 4 |
+| `VectorStoreBackend` | (same 4) | `MilvusVectorStore` (stub) | All 4 (raise NotImplementedError) |
+| `LLMBackend` | classify, generate | `OllamaLLM` | Both |
+| `EmbeddingBackend` | embed, dimension | `OllamaEmbedding` | Both |
+
+---
+
+## Level 4: Acceptance Criteria
+
+### Qdrant has timeout and retry
+
+- **VERIFIED.** Constructor passes `config.backend_timeout_seconds` to `QdrantClient(timeout=...)`.
+- **VERIFIED.** `_retry()` method implements exponential backoff using `config.backend_max_retries` and `config.backend_backoff_base`.
+- **VERIFIED.** All four protocol methods (`ensure_collection`, `upsert_chunks`, `create_payload_index`, `delete_by_ids`) call `self._retry(...)`.
+- **VERIFIED.** Test `test_upsert_chunks_retry_on_failure` confirms retry succeeds on second attempt.
+- **VERIFIED.** Test `test_upsert_chunks_raises_after_retries_exhausted` confirms `ConnectionError` after all retries fail.
+
+### SQLite creates/drops tables, reports schema
+
+- **VERIFIED.** `create_table_from_dataframe()` uses `df.to_sql()` with `if_exists='replace'`.
+- **VERIFIED.** `drop_table()` uses `DROP TABLE IF EXISTS` (no-op if missing).
+- **VERIFIED.** `get_table_schema()` uses `PRAGMA table_info` and returns `{column_name: type_string}`.
+- **VERIFIED.** `table_exists()` queries `sqlite_master`.
+- **VERIFIED.** All tested with real in-memory SQLite (not mocked).
+
+### Ollama LLM classify parses JSON, retry on malformed
+
+- **VERIFIED.** `classify()` posts to `/api/generate` with `format="json"` and `stream=False`.
+- **VERIFIED.** Response text is parsed via `json.loads()`.
+- **VERIFIED.** On `JSONDecodeError`, retries once with a hint appended to the prompt.
+- **VERIFIED.** After two consecutive malformed responses, raises `json.JSONDecodeError`.
+- **VERIFIED.** Tests: `test_classify_retries_on_malformed_json` and `test_classify_raises_after_two_malformed_json`.
+
+### Ollama embedding returns vectors
+
+- **VERIFIED.** `embed()` posts to `/api/embed` and returns `data["embeddings"]`.
+- **VERIFIED.** Empty input returns `[]` immediately.
+- **VERIFIED.** `dimension()` returns the configured `embedding_dimension` value.
+- **VERIFIED.** Has retry with exponential backoff on timeout/connection errors.
+- **VERIFIED.** Test `test_embed_returns_vectors` confirms correct vector extraction.
+
+### Stubs raise NotImplementedError
+
+- **VERIFIED.** `MilvusVectorStore`: all 4 methods raise `NotImplementedError` with "stub" in message.
+- **VERIFIED.** `PostgresStructuredDB`: all 5 methods raise `NotImplementedError` with "stub" in message.
+- **VERIFIED.** 9 tests cover all stub methods.
+
+### Unit tests use mocks only
+
+- **VERIFIED.** Zero `@pytest.mark.integration` markers in test_backends.py.
+- **VERIFIED.** No real network imports (`requests`, `urllib`, `socket`, `subprocess`).
+- **VERIFIED.** Qdrant tests use `unittest.mock.MagicMock` for `QdrantClient`.
+- **VERIFIED.** Ollama tests use `unittest.mock.patch("httpx.post", ...)`.
+- **VERIFIED.** SQLite tests use real `:memory:` database (stdlib, no external service).
+- **VERIFIED.** All 66 tests marked `@pytest.mark.unit`.
+
+---
+
+## File Inventory
+
+### 7 files created
+
+| File | Purpose | Lines |
+|---|---|---|
+| `backends/__init__.py` | Package init with lazy imports | 43 |
+| `backends/sqlite.py` | SQLiteStructuredDB (real implementation) | 108 |
+| `backends/qdrant.py` | QdrantVectorStore (real implementation) | 222 |
+| `backends/ollama.py` | OllamaLLM + OllamaEmbedding (real implementations) | 299 |
+| `backends/milvus.py` | MilvusVectorStore (stub) | 42 |
+| `backends/postgres.py` | PostgresStructuredDB (stub) | 54 |
+| `tests/test_backends.py` | 66 unit tests across 7 test classes | 846 |
+
+### 1 file modified
+
+| File | Change |
+|---|---|
+| `__init__.py` | Added backend imports and `__all__` exports (6 backend classes) |
+
+---
+
+## Architecture Compliance
+
+| Constraint | Status |
+|---|---|
+| No ABC base classes | PASS -- zero ABC/ABCMeta/abstractmethod usage |
+| Structural subtyping only | PASS -- no explicit Protocol inheritance in backends |
+| Logger name `ingestkit_excel` | PASS -- all backends use `logging.getLogger("ingestkit_excel")` |
+| Optional deps guarded | PASS -- qdrant-client and httpx guarded with try/except ImportError |
+| No concrete backends inside core protocols | PASS -- backends are in separate `backends/` subpackage |
+| Config-driven timeout/retry | PASS -- uses `backend_timeout_seconds`, `backend_max_retries`, `backend_backoff_base` |
+
+---
+
+## Summary
+
+All PATCH claims verified:
+
+| Claim | Verified |
+|---|---|
+| 66 new tests in test_backends.py | YES -- 66 collected, 66 passed |
+| 513 total tests passing | YES -- 513 collected, 513 passed |
+| Zero regressions | YES -- no failures in full suite |
+| 7 files created, 1 modified | YES -- exact match |
+| All backends satisfy Protocol (runtime_checkable isinstance) | YES -- all 6 return True |
+
+**VERDICT: PASS -- all claims verified, zero discrepancies.**

--- a/packages/ingestkit-excel/src/ingestkit_excel/__init__.py
+++ b/packages/ingestkit-excel/src/ingestkit_excel/__init__.py
@@ -1,10 +1,19 @@
 """ingestkit-excel -- Excel file ingestion plugin for the ingestkit framework.
 
-Public API exports for models, enums, errors, configuration, and backend
-protocols.  Higher-level components (``ExcelRouter``, ``create_default_router``)
-will be exported here once implemented in subsequent issues.
+Public API exports for models, enums, errors, configuration, backend
+protocols, and concrete backend implementations.  Higher-level components
+(``ExcelRouter``, ``create_default_router``) will be exported here once
+implemented in subsequent issues.
 """
 
+from ingestkit_excel.backends import (
+    MilvusVectorStore,
+    OllamaEmbedding,
+    OllamaLLM,
+    PostgresStructuredDB,
+    QdrantVectorStore,
+    SQLiteStructuredDB,
+)
 from ingestkit_excel.config import ExcelProcessorConfig
 from ingestkit_excel.errors import ErrorCode, IngestError
 from ingestkit_excel.idempotency import compute_ingest_key
@@ -81,4 +90,11 @@ __all__ = [
     "StructuredDBBackend",
     "LLMBackend",
     "EmbeddingBackend",
+    # Concrete backends
+    "SQLiteStructuredDB",
+    "QdrantVectorStore",
+    "OllamaLLM",
+    "OllamaEmbedding",
+    "MilvusVectorStore",
+    "PostgresStructuredDB",
 ]

--- a/packages/ingestkit-excel/src/ingestkit_excel/backends/__init__.py
+++ b/packages/ingestkit-excel/src/ingestkit_excel/backends/__init__.py
@@ -1,0 +1,43 @@
+"""Concrete backend implementations for ingestkit-excel.
+
+Exports all six backend classes.  The concrete backends for Qdrant and Ollama
+require optional dependencies (``qdrant-client`` and ``httpx`` respectively).
+They are guarded with lazy ``try/except ImportError`` blocks so the package
+works even when optional dependencies are not installed.
+
+Stubs (Milvus, PostgreSQL) are always importable and raise
+``NotImplementedError`` on all methods.
+"""
+
+from __future__ import annotations
+
+# --- Always-available backends (stdlib only) ---
+from ingestkit_excel.backends.sqlite import SQLiteStructuredDB
+
+# --- Stubs (no external deps) ---
+from ingestkit_excel.backends.milvus import MilvusVectorStore
+from ingestkit_excel.backends.postgres import PostgresStructuredDB
+
+# --- Optional-dep backends (lazy import guards) ---
+QdrantVectorStore = None
+OllamaLLM = None
+OllamaEmbedding = None
+
+try:
+    from ingestkit_excel.backends.qdrant import QdrantVectorStore  # type: ignore[assignment]
+except ImportError:
+    pass
+
+try:
+    from ingestkit_excel.backends.ollama import OllamaLLM, OllamaEmbedding  # type: ignore[assignment]
+except ImportError:
+    pass
+
+__all__ = [
+    "SQLiteStructuredDB",
+    "QdrantVectorStore",
+    "OllamaLLM",
+    "OllamaEmbedding",
+    "MilvusVectorStore",
+    "PostgresStructuredDB",
+]

--- a/packages/ingestkit-excel/src/ingestkit_excel/backends/milvus.py
+++ b/packages/ingestkit-excel/src/ingestkit_excel/backends/milvus.py
@@ -1,0 +1,41 @@
+"""Milvus backend stub for the VectorStoreBackend protocol.
+
+This module provides a placeholder implementation that raises
+``NotImplementedError`` for all methods.  It exists so that the backend
+registry can list Milvus as a known option and provide a clear error
+message when a caller attempts to use it before a real implementation
+is available.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ingestkit_core.models import ChunkPayload
+
+
+class MilvusVectorStore:
+    """Milvus vector store stub.
+
+    All methods raise ``NotImplementedError``.  Install and configure a
+    real Milvus backend when ready for production use.
+    """
+
+    def upsert_chunks(self, collection: str, chunks: list[ChunkPayload]) -> int:
+        """Not implemented."""
+        raise NotImplementedError("MilvusVectorStore is a stub — not yet implemented.")
+
+    def ensure_collection(self, collection: str, vector_size: int) -> None:
+        """Not implemented."""
+        raise NotImplementedError("MilvusVectorStore is a stub — not yet implemented.")
+
+    def create_payload_index(
+        self, collection: str, field: str, field_type: str
+    ) -> None:
+        """Not implemented."""
+        raise NotImplementedError("MilvusVectorStore is a stub — not yet implemented.")
+
+    def delete_by_ids(self, collection: str, ids: list[str]) -> int:
+        """Not implemented."""
+        raise NotImplementedError("MilvusVectorStore is a stub — not yet implemented.")

--- a/packages/ingestkit-excel/src/ingestkit_excel/backends/ollama.py
+++ b/packages/ingestkit-excel/src/ingestkit_excel/backends/ollama.py
@@ -1,0 +1,298 @@
+"""Ollama backends for the LLMBackend and EmbeddingBackend protocols.
+
+Provides concrete implementations that communicate with a local Ollama server
+via its HTTP API.  Requires ``httpx`` as an optional dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ingestkit_excel.config import ExcelProcessorConfig
+
+logger = logging.getLogger("ingestkit_excel")
+
+
+class OllamaLLM:
+    """Ollama-backed LLM.
+
+    Satisfies :class:`~ingestkit_core.protocols.LLMBackend` via structural
+    subtyping (no inheritance required).
+
+    Parameters
+    ----------
+    base_url:
+        Ollama server base URL (e.g. ``"http://localhost:11434"``).
+    config:
+        Pipeline configuration providing timeout and retry settings.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:11434",
+        config: ExcelProcessorConfig | None = None,
+    ) -> None:
+        try:
+            import httpx  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "httpx is required for OllamaLLM. "
+                "Install it with: pip install 'ingestkit-excel[ollama]'"
+            ) from exc
+
+        from ingestkit_excel.config import ExcelProcessorConfig
+
+        self._base_url = base_url.rstrip("/")
+        self._config = config or ExcelProcessorConfig()
+
+    def _post(
+        self,
+        endpoint: str,
+        payload: dict[str, Any],
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Send a POST request to Ollama and return the JSON response.
+
+        Retries on connection/timeout errors using the configured retry
+        settings.
+        """
+        import httpx
+
+        url = f"{self._base_url}{endpoint}"
+        effective_timeout = timeout or self._config.backend_timeout_seconds
+
+        last_exc: Exception | None = None
+        max_attempts = 1 + self._config.backend_max_retries
+
+        for attempt in range(max_attempts):
+            try:
+                response = httpx.post(
+                    url,
+                    json=payload,
+                    timeout=effective_timeout,
+                )
+                response.raise_for_status()
+                return response.json()
+            except httpx.TimeoutException as exc:
+                last_exc = exc
+                if attempt < max_attempts - 1:
+                    sleep_time = self._config.backend_backoff_base * (2 ** attempt)
+                    logger.warning(
+                        "Ollama request timed out (attempt %d/%d), retrying in %.1fs",
+                        attempt + 1,
+                        max_attempts,
+                        sleep_time,
+                    )
+                    time.sleep(sleep_time)
+            except httpx.HTTPStatusError as exc:
+                last_exc = exc
+                if attempt < max_attempts - 1:
+                    sleep_time = self._config.backend_backoff_base * (2 ** attempt)
+                    logger.warning(
+                        "Ollama request failed with HTTP %d (attempt %d/%d), retrying in %.1fs",
+                        exc.response.status_code,
+                        attempt + 1,
+                        max_attempts,
+                        sleep_time,
+                    )
+                    time.sleep(sleep_time)
+            except httpx.ConnectError as exc:
+                last_exc = exc
+                if attempt < max_attempts - 1:
+                    sleep_time = self._config.backend_backoff_base * (2 ** attempt)
+                    logger.warning(
+                        "Ollama connection failed (attempt %d/%d), retrying in %.1fs",
+                        attempt + 1,
+                        max_attempts,
+                        sleep_time,
+                    )
+                    time.sleep(sleep_time)
+
+        # All retries exhausted
+        if isinstance(last_exc, httpx.TimeoutException):
+            raise TimeoutError(
+                f"Ollama request timed out after {max_attempts} attempts: {last_exc}"
+            ) from last_exc
+
+        raise ConnectionError(
+            f"Ollama connection failed after {max_attempts} attempts: {last_exc}"
+        ) from last_exc
+
+    # ------------------------------------------------------------------
+    # Protocol methods
+    # ------------------------------------------------------------------
+
+    def classify(
+        self,
+        prompt: str,
+        model: str,
+        temperature: float = 0.1,
+        timeout: float | None = None,
+    ) -> dict:
+        """Send a classification prompt and return the parsed JSON response.
+
+        Posts to ``/api/generate`` with ``stream=False`` and ``format="json"``.
+        Retries once if the response is not valid JSON.
+        """
+        payload = {
+            "model": model,
+            "prompt": prompt,
+            "stream": False,
+            "format": "json",
+            "options": {"temperature": temperature},
+        }
+
+        last_exc: Exception | None = None
+        for attempt in range(2):  # 1 original + 1 retry for malformed JSON
+            try:
+                data = self._post("/api/generate", payload, timeout=timeout)
+                response_text = data.get("response", "")
+                return json.loads(response_text)
+            except json.JSONDecodeError as exc:
+                last_exc = exc
+                logger.warning(
+                    "Ollama classify returned malformed JSON (attempt %d/2): %s",
+                    attempt + 1,
+                    exc,
+                )
+                if attempt == 0:
+                    # Retry with a hint appended to the prompt
+                    payload = dict(payload)
+                    payload["prompt"] = (
+                        prompt
+                        + "\n\nIMPORTANT: Your previous response was not valid JSON. "
+                        "Respond with valid JSON only."
+                    )
+
+        raise last_exc  # type: ignore[misc]
+
+    def generate(
+        self,
+        prompt: str,
+        model: str,
+        temperature: float = 0.7,
+        timeout: float | None = None,
+    ) -> str:
+        """Send a generation prompt and return the raw text response."""
+        payload = {
+            "model": model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"temperature": temperature},
+        }
+
+        data = self._post("/api/generate", payload, timeout=timeout)
+        return data.get("response", "")
+
+
+class OllamaEmbedding:
+    """Ollama-backed embedding model.
+
+    Satisfies :class:`~ingestkit_core.protocols.EmbeddingBackend` via
+    structural subtyping (no inheritance required).
+
+    Parameters
+    ----------
+    base_url:
+        Ollama server base URL.
+    model:
+        Embedding model name (e.g. ``"nomic-embed-text"``).
+    embedding_dimension:
+        Expected vector dimensionality.
+    config:
+        Pipeline configuration providing timeout settings.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:11434",
+        model: str = "nomic-embed-text",
+        embedding_dimension: int = 768,
+        config: ExcelProcessorConfig | None = None,
+    ) -> None:
+        try:
+            import httpx  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "httpx is required for OllamaEmbedding. "
+                "Install it with: pip install 'ingestkit-excel[ollama]'"
+            ) from exc
+
+        from ingestkit_excel.config import ExcelProcessorConfig
+
+        self._base_url = base_url.rstrip("/")
+        self._model = model
+        self._dimension = embedding_dimension
+        self._config = config or ExcelProcessorConfig()
+
+    # ------------------------------------------------------------------
+    # Protocol methods
+    # ------------------------------------------------------------------
+
+    def embed(
+        self, texts: list[str], timeout: float | None = None
+    ) -> list[list[float]]:
+        """Embed a batch of texts and return their vector representations.
+
+        Posts to ``/api/embed`` with the configured model.
+        """
+        import httpx
+
+        if not texts:
+            return []
+
+        url = f"{self._base_url}/api/embed"
+        effective_timeout = timeout or self._config.backend_timeout_seconds
+        payload = {
+            "model": self._model,
+            "input": texts,
+        }
+
+        last_exc: Exception | None = None
+        max_attempts = 1 + self._config.backend_max_retries
+
+        for attempt in range(max_attempts):
+            try:
+                response = httpx.post(url, json=payload, timeout=effective_timeout)
+                response.raise_for_status()
+                data = response.json()
+                return data.get("embeddings", [])
+            except httpx.TimeoutException as exc:
+                last_exc = exc
+                if attempt < max_attempts - 1:
+                    sleep_time = self._config.backend_backoff_base * (2 ** attempt)
+                    logger.warning(
+                        "Ollama embed timed out (attempt %d/%d), retrying in %.1fs",
+                        attempt + 1,
+                        max_attempts,
+                        sleep_time,
+                    )
+                    time.sleep(sleep_time)
+            except (httpx.ConnectError, httpx.HTTPStatusError) as exc:
+                last_exc = exc
+                if attempt < max_attempts - 1:
+                    sleep_time = self._config.backend_backoff_base * (2 ** attempt)
+                    logger.warning(
+                        "Ollama embed failed (attempt %d/%d), retrying in %.1fs",
+                        attempt + 1,
+                        max_attempts,
+                        sleep_time,
+                    )
+                    time.sleep(sleep_time)
+
+        if isinstance(last_exc, httpx.TimeoutException):
+            raise TimeoutError(
+                f"Ollama embed timed out after {max_attempts} attempts: {last_exc}"
+            ) from last_exc
+
+        raise ConnectionError(
+            f"Ollama embed connection failed after {max_attempts} attempts: {last_exc}"
+        ) from last_exc
+
+    def dimension(self) -> int:
+        """Return the dimensionality of the embedding vectors."""
+        return self._dimension

--- a/packages/ingestkit-excel/src/ingestkit_excel/backends/postgres.py
+++ b/packages/ingestkit-excel/src/ingestkit_excel/backends/postgres.py
@@ -1,0 +1,53 @@
+"""PostgreSQL backend stub for the StructuredDBBackend protocol.
+
+This module provides a placeholder implementation that raises
+``NotImplementedError`` for all methods.  It exists so that the backend
+registry can list PostgreSQL as a known option and provide a clear error
+message when a caller attempts to use it before a real implementation
+is available.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+class PostgresStructuredDB:
+    """PostgreSQL structured database stub.
+
+    All methods raise ``NotImplementedError``.  Install and configure a
+    real PostgreSQL backend when ready for production use.
+    """
+
+    def create_table_from_dataframe(self, table_name: str, df: pd.DataFrame) -> None:
+        """Not implemented."""
+        raise NotImplementedError(
+            "PostgresStructuredDB is a stub — not yet implemented."
+        )
+
+    def drop_table(self, table_name: str) -> None:
+        """Not implemented."""
+        raise NotImplementedError(
+            "PostgresStructuredDB is a stub — not yet implemented."
+        )
+
+    def table_exists(self, table_name: str) -> bool:
+        """Not implemented."""
+        raise NotImplementedError(
+            "PostgresStructuredDB is a stub — not yet implemented."
+        )
+
+    def get_table_schema(self, table_name: str) -> dict:
+        """Not implemented."""
+        raise NotImplementedError(
+            "PostgresStructuredDB is a stub — not yet implemented."
+        )
+
+    def get_connection_uri(self) -> str:
+        """Not implemented."""
+        raise NotImplementedError(
+            "PostgresStructuredDB is a stub — not yet implemented."
+        )

--- a/packages/ingestkit-excel/src/ingestkit_excel/backends/qdrant.py
+++ b/packages/ingestkit-excel/src/ingestkit_excel/backends/qdrant.py
@@ -1,0 +1,221 @@
+"""Qdrant backend for the VectorStoreBackend protocol.
+
+Provides a concrete implementation backed by ``qdrant-client``.  The client
+library is an optional dependency -- importing this module when ``qdrant-client``
+is not installed will raise ``ImportError`` at class instantiation time only.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ingestkit_core.models import ChunkPayload
+    from ingestkit_excel.config import ExcelProcessorConfig
+
+logger = logging.getLogger("ingestkit_excel")
+
+
+class QdrantVectorStore:
+    """Qdrant-backed vector store.
+
+    Satisfies :class:`~ingestkit_core.protocols.VectorStoreBackend` via
+    structural subtyping (no inheritance required).
+
+    Parameters
+    ----------
+    url:
+        Qdrant server URL (e.g. ``"http://localhost:6333"``).
+    collection_prefix:
+        Prefix prepended to collection names for multi-tenant isolation.
+    config:
+        Pipeline configuration providing timeout and retry settings.
+    """
+
+    def __init__(
+        self,
+        url: str = "http://localhost:6333",
+        collection_prefix: str = "",
+        config: ExcelProcessorConfig | None = None,
+    ) -> None:
+        try:
+            from qdrant_client import QdrantClient
+        except ImportError as exc:
+            raise ImportError(
+                "qdrant-client is required for QdrantVectorStore. "
+                "Install it with: pip install 'ingestkit-excel[qdrant]'"
+            ) from exc
+
+        from ingestkit_excel.config import ExcelProcessorConfig
+
+        self._config = config or ExcelProcessorConfig()
+        self._prefix = collection_prefix
+        self._client = QdrantClient(
+            url=url,
+            timeout=self._config.backend_timeout_seconds,
+        )
+
+    def _prefixed(self, collection: str) -> str:
+        """Return the collection name with the configured prefix."""
+        if self._prefix:
+            return f"{self._prefix}_{collection}"
+        return collection
+
+    def _retry(self, fn, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
+        """Execute *fn* with exponential-backoff retries.
+
+        Uses ``config.backend_max_retries`` and ``config.backend_backoff_base``.
+        """
+        last_exc: Exception | None = None
+        max_attempts = 1 + self._config.backend_max_retries
+        for attempt in range(max_attempts):
+            try:
+                return fn(*args, **kwargs)
+            except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+                if attempt < max_attempts - 1:
+                    sleep_time = self._config.backend_backoff_base * (2 ** attempt)
+                    logger.warning(
+                        "Qdrant operation failed (attempt %d/%d), retrying in %.1fs: %s",
+                        attempt + 1,
+                        max_attempts,
+                        sleep_time,
+                        exc,
+                    )
+                    time.sleep(sleep_time)
+        raise last_exc  # type: ignore[misc]
+
+    # ------------------------------------------------------------------
+    # Protocol methods
+    # ------------------------------------------------------------------
+
+    def ensure_collection(self, collection: str, vector_size: int) -> None:
+        """Create the collection if it does not already exist.
+
+        Uses cosine distance metric.
+        """
+        from qdrant_client.models import Distance, VectorParams
+
+        name = self._prefixed(collection)
+
+        def _create() -> None:
+            if not self._client.collection_exists(name):
+                self._client.create_collection(
+                    collection_name=name,
+                    vectors_config=VectorParams(
+                        size=vector_size,
+                        distance=Distance.COSINE,
+                    ),
+                )
+                logger.info("Created Qdrant collection '%s' (dim=%d)", name, vector_size)
+
+        try:
+            self._retry(_create)
+        except Exception as exc:
+            raise ConnectionError(
+                f"Failed to ensure Qdrant vector collection '{name}': {exc}"
+            ) from exc
+
+    def upsert_chunks(self, collection: str, chunks: list[ChunkPayload]) -> int:
+        """Upsert chunk payloads into the given collection.
+
+        Converts each ``ChunkPayload`` to a Qdrant ``PointStruct`` and performs
+        a batch upsert with retry.
+
+        Returns the number of points upserted.
+        """
+        from qdrant_client.models import PointStruct
+
+        if not chunks:
+            return 0
+
+        name = self._prefixed(collection)
+        points = [
+            PointStruct(
+                id=chunk.id,
+                vector=chunk.vector,
+                payload={
+                    "text": chunk.text,
+                    **chunk.metadata.model_dump(),
+                },
+            )
+            for chunk in chunks
+        ]
+
+        def _upsert() -> None:
+            self._client.upsert(collection_name=name, points=points)
+
+        try:
+            self._retry(_upsert)
+        except Exception as exc:
+            raise ConnectionError(
+                f"Failed to upsert {len(chunks)} chunks to Qdrant vector collection '{name}': {exc}"
+            ) from exc
+
+        logger.info("Upserted %d points to Qdrant collection '%s'", len(points), name)
+        return len(points)
+
+    def create_payload_index(
+        self, collection: str, field: str, field_type: str
+    ) -> None:
+        """Create a payload index on the specified field.
+
+        Parameters
+        ----------
+        field_type:
+            One of ``"keyword"`` or ``"integer"``.
+        """
+        from qdrant_client.models import PayloadSchemaType
+
+        type_map = {
+            "keyword": PayloadSchemaType.KEYWORD,
+            "integer": PayloadSchemaType.INTEGER,
+        }
+        schema_type = type_map.get(field_type)
+        if schema_type is None:
+            raise ValueError(
+                f"Unsupported field_type '{field_type}'. Use 'keyword' or 'integer'."
+            )
+
+        name = self._prefixed(collection)
+
+        def _create_index() -> None:
+            self._client.create_payload_index(
+                collection_name=name,
+                field_name=field,
+                field_schema=schema_type,
+            )
+
+        try:
+            self._retry(_create_index)
+        except Exception as exc:
+            raise ConnectionError(
+                f"Failed to create payload index on Qdrant vector collection '{name}.{field}': {exc}"
+            ) from exc
+
+    def delete_by_ids(self, collection: str, ids: list[str]) -> int:
+        """Delete points by their IDs. Returns count deleted."""
+        from qdrant_client.models import PointIdsList
+
+        if not ids:
+            return 0
+
+        name = self._prefixed(collection)
+
+        def _delete() -> None:
+            self._client.delete(
+                collection_name=name,
+                points_selector=PointIdsList(points=ids),
+            )
+
+        try:
+            self._retry(_delete)
+        except Exception as exc:
+            raise ConnectionError(
+                f"Failed to delete {len(ids)} points from Qdrant vector collection '{name}': {exc}"
+            ) from exc
+
+        logger.info("Deleted %d points from Qdrant collection '%s'", len(ids), name)
+        return len(ids)

--- a/packages/ingestkit-excel/src/ingestkit_excel/backends/sqlite.py
+++ b/packages/ingestkit-excel/src/ingestkit_excel/backends/sqlite.py
@@ -1,0 +1,107 @@
+"""SQLite backend for the StructuredDBBackend protocol.
+
+Provides a concrete implementation backed by Python's built-in ``sqlite3``
+module.  Suitable for local / single-node deployments and testing.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+logger = logging.getLogger("ingestkit_excel")
+
+
+class SQLiteStructuredDB:
+    """SQLite-backed structured database.
+
+    Satisfies :class:`~ingestkit_core.protocols.StructuredDBBackend` via
+    structural subtyping (no inheritance required).
+
+    Parameters
+    ----------
+    db_path:
+        Filesystem path or ``":memory:"`` for an in-memory database.
+    """
+
+    def __init__(self, db_path: str = ":memory:") -> None:
+        self._db_path = db_path
+        try:
+            self._conn = sqlite3.connect(db_path)
+        except sqlite3.Error as exc:
+            raise ConnectionError(
+                f"Failed to connect to SQLite database at {db_path}: {exc}"
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Protocol methods
+    # ------------------------------------------------------------------
+
+    def create_table_from_dataframe(self, table_name: str, df: pd.DataFrame) -> None:
+        """Write a DataFrame as a table, replacing if it already exists.
+
+        Uses ``pandas.DataFrame.to_sql`` with ``if_exists='replace'``.
+
+        Raises
+        ------
+        RuntimeError
+            If the write fails.
+        """
+        import pandas as pd  # noqa: F811 -- runtime import
+
+        try:
+            df.to_sql(table_name, self._conn, if_exists="replace", index=False)
+        except (sqlite3.Error, pd.errors.DatabaseError) as exc:
+            raise RuntimeError(
+                f"Failed to write table '{table_name}': {exc}"
+            ) from exc
+
+    def drop_table(self, table_name: str) -> None:
+        """Drop a table by name (no-op if it does not exist)."""
+        try:
+            self._conn.execute(f"DROP TABLE IF EXISTS [{table_name}]")
+            self._conn.commit()
+        except sqlite3.Error as exc:
+            raise RuntimeError(
+                f"Failed to drop table '{table_name}': {exc}"
+            ) from exc
+
+    def table_exists(self, table_name: str) -> bool:
+        """Return True if the table exists in the database."""
+        cursor = self._conn.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?",
+            (table_name,),
+        )
+        return cursor.fetchone()[0] > 0
+
+    def get_table_schema(self, table_name: str) -> dict:
+        """Return the table schema as ``{column_name: type_string}``.
+
+        Uses ``PRAGMA table_info`` to inspect column definitions.
+        """
+        cursor = self._conn.execute(f"PRAGMA table_info([{table_name}])")
+        rows = cursor.fetchall()
+        # PRAGMA table_info returns: (cid, name, type, notnull, dflt_value, pk)
+        return {row[1]: row[2] for row in rows}
+
+    def get_connection_uri(self) -> str:
+        """Return the database connection URI."""
+        return f"sqlite:///{self._db_path}"
+
+    # ------------------------------------------------------------------
+    # Resource management
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        self._conn.close()
+
+    def __del__(self) -> None:
+        try:
+            self._conn.close()
+        except Exception:  # noqa: BLE001
+            pass

--- a/packages/ingestkit-excel/tests/test_backends.py
+++ b/packages/ingestkit-excel/tests/test_backends.py
@@ -1,0 +1,845 @@
+"""Tests for concrete backend implementations.
+
+Covers SQLite (real in-memory DB), Qdrant (mocked client), Ollama LLM and
+Embedding (mocked httpx), stubs (Milvus, Postgres), and runtime protocol
+conformance checks.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from unittest.mock import MagicMock, Mock, patch
+
+import pandas as pd
+import pytest
+
+from ingestkit_core.models import BaseChunkMetadata, ChunkPayload
+from ingestkit_excel.backends.milvus import MilvusVectorStore
+from ingestkit_excel.backends.postgres import PostgresStructuredDB
+from ingestkit_excel.backends.sqlite import SQLiteStructuredDB
+from ingestkit_excel.config import ExcelProcessorConfig
+from ingestkit_excel.protocols import (
+    EmbeddingBackend,
+    LLMBackend,
+    StructuredDBBackend,
+    VectorStoreBackend,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chunk(
+    id_: str = "chunk-001",
+    text: str = "sample text",
+    vector: list[float] | None = None,
+) -> ChunkPayload:
+    """Create a ChunkPayload for testing."""
+    return ChunkPayload(
+        id=id_,
+        text=text,
+        vector=vector or [0.1, 0.2, 0.3],
+        metadata=BaseChunkMetadata(
+            source_uri="file:///tmp/test.xlsx",
+            source_format="xlsx",
+            ingestion_method="sql_agent",
+            parser_version="ingestkit_excel:1.0.0",
+            chunk_index=0,
+            chunk_hash="abc123",
+            ingest_key="key123",
+            ingest_run_id="run-001",
+            tenant_id="test_tenant",
+            table_name="employees",
+        ),
+    )
+
+
+def _make_config(**overrides) -> ExcelProcessorConfig:
+    """Create a config with fast retry settings for tests."""
+    defaults = {
+        "backend_timeout_seconds": 5.0,
+        "backend_max_retries": 1,
+        "backend_backoff_base": 0.01,  # near-zero for fast tests
+    }
+    defaults.update(overrides)
+    return ExcelProcessorConfig(**defaults)
+
+
+# ===========================================================================
+# TestSQLiteStructuredDB
+# ===========================================================================
+
+
+class TestSQLiteStructuredDB:
+    """Tests for SQLiteStructuredDB using a real in-memory SQLite database."""
+
+    @pytest.fixture()
+    def db(self) -> SQLiteStructuredDB:
+        return SQLiteStructuredDB(db_path=":memory:")
+
+    @pytest.fixture()
+    def sample_df(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "name": ["Alice", "Bob", "Charlie"],
+                "age": [30, 25, 35],
+                "salary": [70000.0, 55000.0, 90000.0],
+            }
+        )
+
+    # --- create_table_from_dataframe ---
+
+    @pytest.mark.unit
+    def test_create_table_writes_data(
+        self, db: SQLiteStructuredDB, sample_df: pd.DataFrame
+    ) -> None:
+        db.create_table_from_dataframe("employees", sample_df)
+
+        assert db.table_exists("employees")
+
+    @pytest.mark.unit
+    def test_create_table_replaces_existing(
+        self, db: SQLiteStructuredDB, sample_df: pd.DataFrame
+    ) -> None:
+        db.create_table_from_dataframe("employees", sample_df)
+        # Create again with different data
+        new_df = pd.DataFrame({"name": ["Dave"], "age": [40], "salary": [80000.0]})
+        db.create_table_from_dataframe("employees", new_df)
+
+        # Should have only 1 row now (replaced, not appended)
+        cursor = db._conn.execute("SELECT COUNT(*) FROM employees")
+        assert cursor.fetchone()[0] == 1
+
+    @pytest.mark.unit
+    def test_create_table_preserves_all_rows(
+        self, db: SQLiteStructuredDB, sample_df: pd.DataFrame
+    ) -> None:
+        db.create_table_from_dataframe("employees", sample_df)
+
+        cursor = db._conn.execute("SELECT COUNT(*) FROM employees")
+        assert cursor.fetchone()[0] == 3
+
+    # --- drop_table ---
+
+    @pytest.mark.unit
+    def test_drop_table_removes_table(
+        self, db: SQLiteStructuredDB, sample_df: pd.DataFrame
+    ) -> None:
+        db.create_table_from_dataframe("employees", sample_df)
+        db.drop_table("employees")
+
+        assert not db.table_exists("employees")
+
+    @pytest.mark.unit
+    def test_drop_table_nonexistent_is_noop(
+        self, db: SQLiteStructuredDB
+    ) -> None:
+        # Should not raise
+        db.drop_table("nonexistent")
+
+    # --- table_exists ---
+
+    @pytest.mark.unit
+    def test_table_exists_returns_false_for_missing(
+        self, db: SQLiteStructuredDB
+    ) -> None:
+        assert not db.table_exists("nonexistent")
+
+    @pytest.mark.unit
+    def test_table_exists_returns_true_after_create(
+        self, db: SQLiteStructuredDB, sample_df: pd.DataFrame
+    ) -> None:
+        db.create_table_from_dataframe("employees", sample_df)
+        assert db.table_exists("employees")
+
+    # --- get_table_schema ---
+
+    @pytest.mark.unit
+    def test_get_table_schema_returns_columns(
+        self, db: SQLiteStructuredDB, sample_df: pd.DataFrame
+    ) -> None:
+        db.create_table_from_dataframe("employees", sample_df)
+
+        schema = db.get_table_schema("employees")
+
+        assert "name" in schema
+        assert "age" in schema
+        assert "salary" in schema
+
+    @pytest.mark.unit
+    def test_get_table_schema_empty_for_missing_table(
+        self, db: SQLiteStructuredDB
+    ) -> None:
+        schema = db.get_table_schema("nonexistent")
+        assert schema == {}
+
+    # --- get_connection_uri ---
+
+    @pytest.mark.unit
+    def test_get_connection_uri_memory(self, db: SQLiteStructuredDB) -> None:
+        assert db.get_connection_uri() == "sqlite:///:memory:"
+
+    @pytest.mark.unit
+    def test_get_connection_uri_file_path(self) -> None:
+        db = SQLiteStructuredDB(db_path="/tmp/test.db")
+        assert db.get_connection_uri() == "sqlite:////tmp/test.db"
+        db.close()
+
+    # --- close ---
+
+    @pytest.mark.unit
+    def test_close_prevents_further_queries(
+        self, db: SQLiteStructuredDB, sample_df: pd.DataFrame
+    ) -> None:
+        db.create_table_from_dataframe("employees", sample_df)
+        db.close()
+
+        with pytest.raises(sqlite3.ProgrammingError):
+            db.table_exists("employees")
+
+
+# ===========================================================================
+# TestQdrantVectorStore
+# ===========================================================================
+
+
+class TestQdrantVectorStore:
+    """Tests for QdrantVectorStore using a mocked qdrant_client."""
+
+    @pytest.fixture()
+    def mock_qdrant_client(self):
+        """Create a mock QdrantClient."""
+        mock_client = MagicMock()
+        mock_client.collection_exists.return_value = False
+        return mock_client
+
+    @pytest.fixture()
+    def store(self, mock_qdrant_client):
+        """Create a QdrantVectorStore with mocked client."""
+        config = _make_config()
+        with patch("qdrant_client.QdrantClient", return_value=mock_qdrant_client):
+            from ingestkit_excel.backends.qdrant import QdrantVectorStore
+
+            store = QdrantVectorStore(
+                url="http://localhost:6333",
+                collection_prefix="test",
+                config=config,
+            )
+        return store
+
+    # --- ensure_collection ---
+
+    @pytest.mark.unit
+    def test_ensure_collection_creates_when_not_exists(
+        self, store, mock_qdrant_client
+    ) -> None:
+        store.ensure_collection("helpdesk", vector_size=768)
+
+        mock_qdrant_client.collection_exists.assert_called_with("test_helpdesk")
+        mock_qdrant_client.create_collection.assert_called_once()
+
+    @pytest.mark.unit
+    def test_ensure_collection_skips_when_exists(
+        self, store, mock_qdrant_client
+    ) -> None:
+        mock_qdrant_client.collection_exists.return_value = True
+
+        store.ensure_collection("helpdesk", vector_size=768)
+
+        mock_qdrant_client.create_collection.assert_not_called()
+
+    @pytest.mark.unit
+    def test_ensure_collection_uses_prefix(
+        self, store, mock_qdrant_client
+    ) -> None:
+        store.ensure_collection("mydata", vector_size=128)
+
+        mock_qdrant_client.collection_exists.assert_called_with("test_mydata")
+
+    # --- upsert_chunks ---
+
+    @pytest.mark.unit
+    def test_upsert_chunks_returns_count(
+        self, store, mock_qdrant_client
+    ) -> None:
+        chunks = [_make_chunk(id_="c1"), _make_chunk(id_="c2")]
+
+        count = store.upsert_chunks("helpdesk", chunks)
+
+        assert count == 2
+        mock_qdrant_client.upsert.assert_called_once()
+
+    @pytest.mark.unit
+    def test_upsert_chunks_empty_returns_zero(
+        self, store, mock_qdrant_client
+    ) -> None:
+        count = store.upsert_chunks("helpdesk", [])
+
+        assert count == 0
+        mock_qdrant_client.upsert.assert_not_called()
+
+    @pytest.mark.unit
+    def test_upsert_chunks_passes_correct_collection_name(
+        self, store, mock_qdrant_client
+    ) -> None:
+        chunks = [_make_chunk()]
+
+        store.upsert_chunks("helpdesk", chunks)
+
+        call_kwargs = mock_qdrant_client.upsert.call_args
+        assert call_kwargs.kwargs["collection_name"] == "test_helpdesk"
+
+    @pytest.mark.unit
+    def test_upsert_chunks_converts_to_point_structs(
+        self, store, mock_qdrant_client
+    ) -> None:
+        chunk = _make_chunk(id_="pt-1", text="hello", vector=[1.0, 2.0, 3.0])
+
+        store.upsert_chunks("helpdesk", [chunk])
+
+        call_kwargs = mock_qdrant_client.upsert.call_args
+        points = call_kwargs.kwargs["points"]
+        assert len(points) == 1
+        assert points[0].id == "pt-1"
+        assert points[0].vector == [1.0, 2.0, 3.0]
+        assert points[0].payload["text"] == "hello"
+
+    @pytest.mark.unit
+    def test_upsert_chunks_retry_on_failure(
+        self, store, mock_qdrant_client
+    ) -> None:
+        mock_qdrant_client.upsert.side_effect = [
+            RuntimeError("network error"),
+            None,  # success on retry
+        ]
+
+        count = store.upsert_chunks("helpdesk", [_make_chunk()])
+
+        assert count == 1
+        assert mock_qdrant_client.upsert.call_count == 2
+
+    @pytest.mark.unit
+    def test_upsert_chunks_raises_after_retries_exhausted(
+        self, store, mock_qdrant_client
+    ) -> None:
+        mock_qdrant_client.upsert.side_effect = RuntimeError("persistent failure")
+
+        with pytest.raises(ConnectionError, match="vector collection"):
+            store.upsert_chunks("helpdesk", [_make_chunk()])
+
+    # --- create_payload_index ---
+
+    @pytest.mark.unit
+    def test_create_payload_index_keyword(
+        self, store, mock_qdrant_client
+    ) -> None:
+        store.create_payload_index("helpdesk", "tenant_id", "keyword")
+
+        mock_qdrant_client.create_payload_index.assert_called_once()
+
+    @pytest.mark.unit
+    def test_create_payload_index_integer(
+        self, store, mock_qdrant_client
+    ) -> None:
+        store.create_payload_index("helpdesk", "chunk_index", "integer")
+
+        mock_qdrant_client.create_payload_index.assert_called_once()
+
+    @pytest.mark.unit
+    def test_create_payload_index_invalid_type_raises(
+        self, store
+    ) -> None:
+        with pytest.raises(ValueError, match="Unsupported field_type"):
+            store.create_payload_index("helpdesk", "field", "boolean")
+
+    # --- delete_by_ids ---
+
+    @pytest.mark.unit
+    def test_delete_by_ids_returns_count(
+        self, store, mock_qdrant_client
+    ) -> None:
+        count = store.delete_by_ids("helpdesk", ["id1", "id2", "id3"])
+
+        assert count == 3
+        mock_qdrant_client.delete.assert_called_once()
+
+    @pytest.mark.unit
+    def test_delete_by_ids_empty_returns_zero(
+        self, store, mock_qdrant_client
+    ) -> None:
+        count = store.delete_by_ids("helpdesk", [])
+
+        assert count == 0
+        mock_qdrant_client.delete.assert_not_called()
+
+    # --- prefix behavior ---
+
+    @pytest.mark.unit
+    def test_no_prefix_uses_raw_collection_name(self, mock_qdrant_client) -> None:
+        config = _make_config()
+        with patch("qdrant_client.QdrantClient", return_value=mock_qdrant_client):
+            from ingestkit_excel.backends.qdrant import QdrantVectorStore
+
+            store = QdrantVectorStore(
+                url="http://localhost:6333",
+                collection_prefix="",
+                config=config,
+            )
+        store.ensure_collection("helpdesk", vector_size=768)
+
+        mock_qdrant_client.collection_exists.assert_called_with("helpdesk")
+
+
+# ===========================================================================
+# TestOllamaLLM
+# ===========================================================================
+
+
+class TestOllamaLLM:
+    """Tests for OllamaLLM using mocked httpx."""
+
+    @pytest.fixture()
+    def config(self) -> ExcelProcessorConfig:
+        return _make_config()
+
+    @pytest.fixture()
+    def mock_response(self):
+        """Create a mock httpx response."""
+        resp = Mock()
+        resp.status_code = 200
+        resp.raise_for_status = Mock()
+        return resp
+
+    # --- classify ---
+
+    @pytest.mark.unit
+    def test_classify_returns_parsed_json(self, config, mock_response) -> None:
+        classify_result = {"type": "tabular_data", "confidence": 0.9, "reasoning": "test"}
+        mock_response.json.return_value = {"response": json.dumps(classify_result)}
+
+        with patch("httpx.post", return_value=mock_response):
+            from ingestkit_excel.backends.ollama import OllamaLLM
+
+            llm = OllamaLLM(config=config)
+            result = llm.classify("test prompt", "qwen2.5:7b")
+
+        assert result == classify_result
+
+    @pytest.mark.unit
+    def test_classify_posts_to_correct_endpoint(self, config, mock_response) -> None:
+        mock_response.json.return_value = {"response": '{"type": "tabular_data", "confidence": 0.9, "reasoning": "ok"}'}
+
+        with patch("httpx.post", return_value=mock_response) as mock_post:
+            from ingestkit_excel.backends.ollama import OllamaLLM
+
+            llm = OllamaLLM(base_url="http://myhost:11434", config=config)
+            llm.classify("prompt", "model")
+
+        call_args = mock_post.call_args
+        assert call_args.args[0] == "http://myhost:11434/api/generate"
+
+    @pytest.mark.unit
+    def test_classify_sends_json_format(self, config, mock_response) -> None:
+        mock_response.json.return_value = {"response": '{"type": "tabular_data", "confidence": 0.9, "reasoning": "ok"}'}
+
+        with patch("httpx.post", return_value=mock_response) as mock_post:
+            from ingestkit_excel.backends.ollama import OllamaLLM
+
+            llm = OllamaLLM(config=config)
+            llm.classify("prompt", "model")
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["format"] == "json"
+        assert payload["stream"] is False
+
+    @pytest.mark.unit
+    def test_classify_retries_on_malformed_json(self, config) -> None:
+        resp1 = Mock()
+        resp1.raise_for_status = Mock()
+        resp1.json.return_value = {"response": "not json {{{"}
+
+        resp2 = Mock()
+        resp2.raise_for_status = Mock()
+        resp2.json.return_value = {"response": '{"type": "tabular_data", "confidence": 0.9, "reasoning": "ok"}'}
+
+        with patch("httpx.post", side_effect=[resp1, resp2]):
+            from ingestkit_excel.backends.ollama import OllamaLLM
+
+            llm = OllamaLLM(config=config)
+            result = llm.classify("prompt", "model")
+
+        assert result["type"] == "tabular_data"
+
+    @pytest.mark.unit
+    def test_classify_raises_after_two_malformed_json(self, config) -> None:
+        resp = Mock()
+        resp.raise_for_status = Mock()
+        resp.json.return_value = {"response": "not json"}
+
+        with patch("httpx.post", return_value=resp):
+            from ingestkit_excel.backends.ollama import OllamaLLM
+
+            llm = OllamaLLM(config=config)
+
+            with pytest.raises(json.JSONDecodeError):
+                llm.classify("prompt", "model")
+
+    @pytest.mark.unit
+    def test_classify_passes_temperature(self, config, mock_response) -> None:
+        mock_response.json.return_value = {"response": '{"type": "tabular_data", "confidence": 0.9, "reasoning": "ok"}'}
+
+        with patch("httpx.post", return_value=mock_response) as mock_post:
+            from ingestkit_excel.backends.ollama import OllamaLLM
+
+            llm = OllamaLLM(config=config)
+            llm.classify("prompt", "model", temperature=0.3)
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["options"]["temperature"] == 0.3
+
+    # --- generate ---
+
+    @pytest.mark.unit
+    def test_generate_returns_raw_text(self, config, mock_response) -> None:
+        mock_response.json.return_value = {"response": "Generated text here"}
+
+        with patch("httpx.post", return_value=mock_response):
+            from ingestkit_excel.backends.ollama import OllamaLLM
+
+            llm = OllamaLLM(config=config)
+            result = llm.generate("prompt", "model")
+
+        assert result == "Generated text here"
+
+    @pytest.mark.unit
+    def test_generate_does_not_use_json_format(self, config, mock_response) -> None:
+        mock_response.json.return_value = {"response": "text"}
+
+        with patch("httpx.post", return_value=mock_response) as mock_post:
+            from ingestkit_excel.backends.ollama import OllamaLLM
+
+            llm = OllamaLLM(config=config)
+            llm.generate("prompt", "model")
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert "format" not in payload
+
+    # --- timeout handling ---
+
+    @pytest.mark.unit
+    def test_timeout_raises_timeout_error(self, config) -> None:
+        import httpx
+
+        with patch("httpx.post", side_effect=httpx.TimeoutException("timeout")):
+            from ingestkit_excel.backends.ollama import OllamaLLM
+
+            llm = OllamaLLM(config=config)
+
+            with pytest.raises(TimeoutError, match="timed out"):
+                llm.generate("prompt", "model")
+
+    @pytest.mark.unit
+    def test_connection_error_raises_connection_error(self, config) -> None:
+        import httpx
+
+        with patch("httpx.post", side_effect=httpx.ConnectError("refused")):
+            from ingestkit_excel.backends.ollama import OllamaLLM
+
+            llm = OllamaLLM(config=config)
+
+            with pytest.raises(ConnectionError, match="connection failed"):
+                llm.generate("prompt", "model")
+
+
+# ===========================================================================
+# TestOllamaEmbedding
+# ===========================================================================
+
+
+class TestOllamaEmbedding:
+    """Tests for OllamaEmbedding using mocked httpx."""
+
+    @pytest.fixture()
+    def config(self) -> ExcelProcessorConfig:
+        return _make_config()
+
+    # --- embed ---
+
+    @pytest.mark.unit
+    def test_embed_returns_vectors(self, config) -> None:
+        mock_resp = Mock()
+        mock_resp.raise_for_status = Mock()
+        mock_resp.json.return_value = {
+            "embeddings": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        }
+
+        with patch("httpx.post", return_value=mock_resp):
+            from ingestkit_excel.backends.ollama import OllamaEmbedding
+
+            emb = OllamaEmbedding(model="nomic-embed-text", embedding_dimension=3, config=config)
+            result = emb.embed(["hello", "world"])
+
+        assert len(result) == 2
+        assert result[0] == [0.1, 0.2, 0.3]
+
+    @pytest.mark.unit
+    def test_embed_empty_returns_empty(self, config) -> None:
+        from ingestkit_excel.backends.ollama import OllamaEmbedding
+
+        emb = OllamaEmbedding(config=config)
+        result = emb.embed([])
+
+        assert result == []
+
+    @pytest.mark.unit
+    def test_embed_posts_to_correct_endpoint(self, config) -> None:
+        mock_resp = Mock()
+        mock_resp.raise_for_status = Mock()
+        mock_resp.json.return_value = {"embeddings": [[0.1]]}
+
+        with patch("httpx.post", return_value=mock_resp) as mock_post:
+            from ingestkit_excel.backends.ollama import OllamaEmbedding
+
+            emb = OllamaEmbedding(
+                base_url="http://myhost:11434",
+                model="nomic-embed-text",
+                config=config,
+            )
+            emb.embed(["hello"])
+
+        call_args = mock_post.call_args
+        assert call_args.args[0] == "http://myhost:11434/api/embed"
+
+    @pytest.mark.unit
+    def test_embed_sends_model_name(self, config) -> None:
+        mock_resp = Mock()
+        mock_resp.raise_for_status = Mock()
+        mock_resp.json.return_value = {"embeddings": [[0.1]]}
+
+        with patch("httpx.post", return_value=mock_resp) as mock_post:
+            from ingestkit_excel.backends.ollama import OllamaEmbedding
+
+            emb = OllamaEmbedding(model="custom-embed", config=config)
+            emb.embed(["hello"])
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["model"] == "custom-embed"
+
+    @pytest.mark.unit
+    def test_embed_timeout_raises_timeout_error(self, config) -> None:
+        import httpx
+
+        with patch("httpx.post", side_effect=httpx.TimeoutException("timeout")):
+            from ingestkit_excel.backends.ollama import OllamaEmbedding
+
+            emb = OllamaEmbedding(config=config)
+
+            with pytest.raises(TimeoutError, match="embed timed out"):
+                emb.embed(["hello"])
+
+    @pytest.mark.unit
+    def test_embed_connection_error_raises(self, config) -> None:
+        import httpx
+
+        with patch("httpx.post", side_effect=httpx.ConnectError("refused")):
+            from ingestkit_excel.backends.ollama import OllamaEmbedding
+
+            emb = OllamaEmbedding(config=config)
+
+            with pytest.raises(ConnectionError, match="embed connection failed"):
+                emb.embed(["hello"])
+
+    # --- dimension ---
+
+    @pytest.mark.unit
+    def test_dimension_returns_configured_value(self, config) -> None:
+        from ingestkit_excel.backends.ollama import OllamaEmbedding
+
+        emb = OllamaEmbedding(embedding_dimension=768, config=config)
+        assert emb.dimension() == 768
+
+    @pytest.mark.unit
+    def test_dimension_default_is_768(self, config) -> None:
+        from ingestkit_excel.backends.ollama import OllamaEmbedding
+
+        emb = OllamaEmbedding(config=config)
+        assert emb.dimension() == 768
+
+    @pytest.mark.unit
+    def test_dimension_custom_value(self, config) -> None:
+        from ingestkit_excel.backends.ollama import OllamaEmbedding
+
+        emb = OllamaEmbedding(embedding_dimension=384, config=config)
+        assert emb.dimension() == 384
+
+
+# ===========================================================================
+# TestStubs
+# ===========================================================================
+
+
+class TestStubs:
+    """Tests for stub backends that raise NotImplementedError."""
+
+    # --- MilvusVectorStore ---
+
+    @pytest.mark.unit
+    def test_milvus_upsert_raises(self) -> None:
+        store = MilvusVectorStore()
+        with pytest.raises(NotImplementedError, match="stub"):
+            store.upsert_chunks("col", [])
+
+    @pytest.mark.unit
+    def test_milvus_ensure_collection_raises(self) -> None:
+        store = MilvusVectorStore()
+        with pytest.raises(NotImplementedError, match="stub"):
+            store.ensure_collection("col", 768)
+
+    @pytest.mark.unit
+    def test_milvus_create_payload_index_raises(self) -> None:
+        store = MilvusVectorStore()
+        with pytest.raises(NotImplementedError, match="stub"):
+            store.create_payload_index("col", "field", "keyword")
+
+    @pytest.mark.unit
+    def test_milvus_delete_by_ids_raises(self) -> None:
+        store = MilvusVectorStore()
+        with pytest.raises(NotImplementedError, match="stub"):
+            store.delete_by_ids("col", ["id1"])
+
+    # --- PostgresStructuredDB ---
+
+    @pytest.mark.unit
+    def test_postgres_create_table_raises(self) -> None:
+        db = PostgresStructuredDB()
+        with pytest.raises(NotImplementedError, match="stub"):
+            db.create_table_from_dataframe("tbl", pd.DataFrame())
+
+    @pytest.mark.unit
+    def test_postgres_drop_table_raises(self) -> None:
+        db = PostgresStructuredDB()
+        with pytest.raises(NotImplementedError, match="stub"):
+            db.drop_table("tbl")
+
+    @pytest.mark.unit
+    def test_postgres_table_exists_raises(self) -> None:
+        db = PostgresStructuredDB()
+        with pytest.raises(NotImplementedError, match="stub"):
+            db.table_exists("tbl")
+
+    @pytest.mark.unit
+    def test_postgres_get_table_schema_raises(self) -> None:
+        db = PostgresStructuredDB()
+        with pytest.raises(NotImplementedError, match="stub"):
+            db.get_table_schema("tbl")
+
+    @pytest.mark.unit
+    def test_postgres_get_connection_uri_raises(self) -> None:
+        db = PostgresStructuredDB()
+        with pytest.raises(NotImplementedError, match="stub"):
+            db.get_connection_uri()
+
+
+# ===========================================================================
+# TestProtocolConformance
+# ===========================================================================
+
+
+class TestProtocolConformance:
+    """Tests that concrete backends satisfy their corresponding Protocol."""
+
+    @pytest.mark.unit
+    def test_sqlite_satisfies_structured_db_protocol(self) -> None:
+        db = SQLiteStructuredDB()
+        assert isinstance(db, StructuredDBBackend)
+
+    @pytest.mark.unit
+    def test_qdrant_satisfies_vector_store_protocol(self) -> None:
+        config = _make_config()
+        mock_client = MagicMock()
+        with patch("qdrant_client.QdrantClient", return_value=mock_client):
+            from ingestkit_excel.backends.qdrant import QdrantVectorStore
+
+            store = QdrantVectorStore(config=config)
+
+        assert isinstance(store, VectorStoreBackend)
+
+    @pytest.mark.unit
+    def test_ollama_llm_satisfies_llm_protocol(self) -> None:
+        from ingestkit_excel.backends.ollama import OllamaLLM
+
+        llm = OllamaLLM()
+        assert isinstance(llm, LLMBackend)
+
+    @pytest.mark.unit
+    def test_ollama_embedding_satisfies_embedding_protocol(self) -> None:
+        from ingestkit_excel.backends.ollama import OllamaEmbedding
+
+        emb = OllamaEmbedding()
+        assert isinstance(emb, EmbeddingBackend)
+
+    @pytest.mark.unit
+    def test_milvus_stub_satisfies_vector_store_protocol(self) -> None:
+        store = MilvusVectorStore()
+        assert isinstance(store, VectorStoreBackend)
+
+    @pytest.mark.unit
+    def test_postgres_stub_satisfies_structured_db_protocol(self) -> None:
+        db = PostgresStructuredDB()
+        assert isinstance(db, StructuredDBBackend)
+
+
+# ===========================================================================
+# TestBackendsPackageImport
+# ===========================================================================
+
+
+class TestBackendsPackageImport:
+    """Tests for the backends package __init__.py imports."""
+
+    @pytest.mark.unit
+    def test_sqlite_importable(self) -> None:
+        from ingestkit_excel.backends import SQLiteStructuredDB
+
+        assert SQLiteStructuredDB is not None
+
+    @pytest.mark.unit
+    def test_stubs_importable(self) -> None:
+        from ingestkit_excel.backends import MilvusVectorStore, PostgresStructuredDB
+
+        assert MilvusVectorStore is not None
+        assert PostgresStructuredDB is not None
+
+    @pytest.mark.unit
+    def test_qdrant_importable_when_available(self) -> None:
+        from ingestkit_excel.backends import QdrantVectorStore
+
+        # May be None if qdrant-client not installed, but import should not fail
+        # If installed, should be the class
+        if QdrantVectorStore is not None:
+            assert hasattr(QdrantVectorStore, "upsert_chunks")
+
+    @pytest.mark.unit
+    def test_ollama_importable_when_available(self) -> None:
+        from ingestkit_excel.backends import OllamaEmbedding, OllamaLLM
+
+        # May be None if httpx not installed, but import should not fail
+        if OllamaLLM is not None:
+            assert hasattr(OllamaLLM, "classify")
+        if OllamaEmbedding is not None:
+            assert hasattr(OllamaEmbedding, "embed")
+
+    @pytest.mark.unit
+    def test_main_package_exports_backends(self) -> None:
+        from ingestkit_excel import (
+            MilvusVectorStore,
+            PostgresStructuredDB,
+            SQLiteStructuredDB,
+        )
+
+        assert SQLiteStructuredDB is not None
+        assert MilvusVectorStore is not None
+        assert PostgresStructuredDB is not None


### PR DESCRIPTION
## What
Reference backend implementations for all 4 Protocols: QdrantVectorStore, SQLiteStructuredDB, OllamaLLM, OllamaEmbedding, plus MilvusVectorStore and PostgresStructuredDB stubs.

## Why
Closes #11 — Provides concrete backends for the dev stack (Qdrant, SQLite, Ollama) so the pipeline can run end-to-end.

## How
- **Qdrant**: qdrant-client with exponential backoff retry, ChunkPayload→PointStruct conversion
- **SQLite**: stdlib sqlite3 + pandas to_sql(), in-memory or file-based
- **Ollama**: httpx POST to /api/generate and /api/embed, JSON retry on classify
- **Stubs**: MilvusVectorStore and PostgresStructuredDB raise NotImplementedError
- All backends satisfy @runtime_checkable Protocol (isinstance verified)

## Stack
- [x] Backend

## Verification
- [x] `pytest tests/test_backends.py -v` passes (66 tests)
- [x] `pytest tests/ -v` passes (513 tests, zero regressions)
- [x] All 6 backends importable from `ingestkit_excel.backends`

## Risks / Rollback
Low risk — new backends/ directory, no changes to core processing.

---
Artifacts: `.agents/outputs/*-11-*.md`