### PR TITLE
feat(ingestkit-excel): Implement ExcelRouter orchestrator and public API (#12)

### DIFF
--- a/.agents/outputs/map-12-021226.md
+++ b/.agents/outputs/map-12-021226.md
@@ -1,0 +1,302 @@
+# MAP -- Issue #12: ExcelRouter
+
+## SPEC Requirements
+
+### Section 13 -- Router (`router.py`)
+
+**Constructor:**
+```python
+class ExcelRouter:
+    def __init__(
+        self,
+        vector_store: VectorStoreBackend,
+        structured_db: StructuredDBBackend,
+        llm: LLMBackend,
+        embedder: EmbeddingBackend,
+        config: ExcelProcessorConfig | None = None,
+    ): ...
+```
+
+**`process(file_path, source_uri=None) -> ProcessingResult` flow (12 steps):**
+
+1. Compute `ingest_key` via `compute_ingest_key(file_path, config.parser_version, config.tenant_id, source_uri)` -- returns `IngestKey`, use `.key` property for the hex digest string.
+2. Generate `ingest_run_id` = `str(uuid.uuid4())`.
+3. Parse file via `ParserChain.parse()` -- returns `(FileProfile, list[IngestError])`.
+4. Classify via `ExcelInspector.classify(profile)` -- Tier 1.
+5. If inconclusive (confidence == 0.0) -- call `LLMClassifier.classify(profile, ClassificationTier.LLM_BASIC)` -- Tier 2.
+6. If still low confidence (< `config.tier2_confidence_threshold`, default 0.6) and `config.enable_tier3` is True -- call `LLMClassifier.classify(profile, ClassificationTier.LLM_REASONING)` -- Tier 3.
+7. If all tiers fail -- return `ProcessingResult` with `E_CLASSIFY_INCONCLUSIVE` (fail-closed, zero chunks/tables).
+8. Route to processor based on `ClassificationResult.file_type`:
+   - `TABULAR_DATA` -> `StructuredDBProcessor.process()`
+   - `FORMATTED_DOCUMENT` -> `TextSerializer.process()`
+   - `HYBRID` -> `HybridSplitter.process()`
+9. Collect `WrittenArtifacts` from processor result.
+10. Assemble `ProcessingResult` with all stage artifacts.
+11. Log the result (PII-safe).
+12. Return `ProcessingResult`.
+
+**`process_batch(file_paths) -> list[ProcessingResult]`:** Process multiple files sequentially.
+
+### Section 15 -- Logging
+
+- Logger name: `ingestkit_excel`
+- **INFO**: `file=X | ingest_key=X | tier=X | type=X | confidence=X | path=X | chunks=X | tables=X | parser=X | time=Xs`
+- **WARNING**: fallbacks and non-fatal issues with code
+- **ERROR**: fatal failures with code
+- **DEBUG**: opt-in only via `log_sample_data`, `log_llm_prompts`, `log_chunk_previews`
+- Redaction via `config.redact_patterns`
+
+### Section 16 -- Public API
+
+**Top-level exports from `__init__.py`:**
+```python
+from ingestkit_excel.router import ExcelRouter
+# ... all existing exports plus ExcelRouter and create_default_router
+```
+
+**`create_default_router(**overrides) -> ExcelRouter`:**
+- Convenience factory using default backends (Qdrant, SQLite, Ollama).
+- Accepts overrides for config params.
+
+---
+
+## Module Interfaces
+
+### ParserChain.parse()
+
+**File:** `packages/ingestkit-excel/src/ingestkit_excel/parser_chain.py`
+
+```python
+class ParserChain:
+    def __init__(self, config: ExcelProcessorConfig) -> None: ...
+    def parse(self, file_path: str) -> tuple[FileProfile, list[IngestError]]: ...
+```
+
+- Takes a file path string.
+- Returns `(FileProfile, list[IngestError])` where errors include both fatal errors and non-fatal warnings.
+- FileProfile contains: `file_path`, `file_size_bytes`, `sheet_count`, `sheet_names`, `sheets: list[SheetProfile]`, `has_password_protected_sheets`, `has_chart_only_sheets`, `total_merged_cells`, `total_rows`, `content_hash`.
+- Raises `FileNotFoundError` if file doesn't exist.
+- Can return an empty FileProfile (sheet_count=0) for empty/corrupt/password-protected files.
+
+### ExcelInspector.classify()
+
+**File:** `packages/ingestkit-excel/src/ingestkit_excel/inspector.py`
+
+```python
+class ExcelInspector:
+    def __init__(self, config: ExcelProcessorConfig) -> None: ...
+    def classify(self, profile: FileProfile) -> ClassificationResult: ...
+```
+
+- Takes a `FileProfile`.
+- Returns `ClassificationResult` with: `file_type`, `confidence`, `tier_used` (always `ClassificationTier.RULE_BASED`), `reasoning`, `per_sheet_types` (if hybrid), `signals`.
+- **Inconclusive detection**: confidence == 0.0. This happens when:
+  - No sheets at all (returns HYBRID with confidence=0.0).
+  - Any sheet has < 3 signals matching either type (returns HYBRID with confidence=0.0, reasoning starts with "Inconclusive:").
+- High confidence: 0.9 (>= 4 signals agree).
+- Medium confidence: 0.7 (3 signals agree).
+- Hybrid from disagreement: 0.9 confidence.
+
+### LLMClassifier.classify()
+
+**File:** `packages/ingestkit-excel/src/ingestkit_excel/llm_classifier.py`
+
+```python
+class LLMClassifier:
+    def __init__(self, llm: LLMBackend, config: ExcelProcessorConfig) -> None: ...
+    def classify(
+        self,
+        profile: FileProfile,
+        tier: ClassificationTier,
+    ) -> ClassificationResult: ...
+```
+
+- Takes a `FileProfile` and a `ClassificationTier` (must be `LLM_BASIC` or `LLM_REASONING`).
+- Raises `ValueError` if tier is `RULE_BASED`.
+- Selects model: `LLM_BASIC` -> `config.classification_model`, `LLM_REASONING` -> `config.reasoning_model`.
+- Has built-in retry logic (2 attempts) with correction hints.
+- Returns `ClassificationResult` with file_type, confidence, tier_used, reasoning.
+- **On failure** (all retries exhausted): returns `ClassificationResult` with confidence=0.0 and arbitrary file_type, indicating failure.
+- Does NOT handle tier escalation -- that is the router's responsibility.
+
+**Tier escalation logic (for the router):**
+- Tier 2: Called when Tier 1 is inconclusive (confidence == 0.0).
+- Tier 3: Called when Tier 2 confidence < `config.tier2_confidence_threshold` (0.6) AND `config.enable_tier3` is True.
+- Fail-closed: If all tiers produce confidence < threshold, return E_CLASSIFY_INCONCLUSIVE.
+
+### Processor process() signatures
+
+All three processors share an identical `process()` signature:
+
+```python
+def process(
+    self,
+    file_path: str,
+    profile: FileProfile,
+    ingest_key: str,
+    ingest_run_id: str,
+    parse_result: ParseStageResult,
+    classification_result: ClassificationStageResult,
+    classification: ClassificationResult,
+) -> ProcessingResult: ...
+```
+
+**StructuredDBProcessor** (`processors/structured_db.py`):
+```python
+def __init__(
+    self,
+    structured_db: StructuredDBBackend,
+    vector_store: VectorStoreBackend,
+    embedder: EmbeddingBackend,
+    config: ExcelProcessorConfig,
+) -> None: ...
+```
+
+**TextSerializer** (`processors/serializer.py`):
+```python
+def __init__(
+    self,
+    vector_store: VectorStoreBackend,
+    embedder: EmbeddingBackend,
+    config: ExcelProcessorConfig,
+) -> None: ...
+```
+
+**HybridSplitter** (`processors/splitter.py`):
+```python
+def __init__(
+    self,
+    structured_processor: object,  # StructuredDBProcessor instance
+    text_serializer: object,       # TextSerializer instance
+    config: ExcelProcessorConfig,
+) -> None: ...
+```
+- Note: HybridSplitter extracts backends from the structured_processor's private `_db`, `_vector_store`, `_embedder` attributes.
+
+### compute_ingest_key()
+
+**File:** `packages/ingestkit-core/src/ingestkit_core/idempotency.py` (re-exported from `ingestkit_excel.idempotency`)
+
+```python
+def compute_ingest_key(
+    file_path: str,
+    parser_version: str,
+    tenant_id: str | None = None,
+    source_uri: str | None = None,
+) -> IngestKey: ...
+```
+
+- Returns `IngestKey` Pydantic model.
+- Use `ingest_key_obj.key` property to get the SHA-256 hex digest string (what processors expect as `ingest_key: str`).
+- Reads raw file bytes, computes content_hash, derives source_uri from absolute path if not provided.
+- Can raise `FileNotFoundError`.
+
+---
+
+## Config Parameters (Router-Relevant)
+
+| Parameter | Type | Default | Usage in Router |
+|-----------|------|---------|----------------|
+| `parser_version` | str | `"ingestkit_excel:1.0.0"` | Passed to `compute_ingest_key()` |
+| `tenant_id` | str \| None | None | Passed to `compute_ingest_key()` and into `ProcessingResult` |
+| `tier2_confidence_threshold` | float | 0.6 | Decides Tier 2->3 escalation |
+| `enable_tier3` | bool | True | Whether Tier 3 is attempted |
+| `classification_model` | str | `"qwen2.5:7b"` | Used by LLMClassifier internally |
+| `reasoning_model` | str | `"deepseek-r1:14b"` | Used by LLMClassifier internally |
+| `log_sample_data` | bool | False | PII-safe logging control |
+| `log_llm_prompts` | bool | False | PII-safe logging control |
+| `log_chunk_previews` | bool | False | PII-safe logging control |
+| `redact_patterns` | list[str] | [] | PII redaction patterns |
+| `default_collection` | str | `"helpdesk"` | Vector store collection name |
+
+---
+
+## Error Codes (Router-Relevant)
+
+| Code | Type | When Used |
+|------|------|-----------|
+| `E_CLASSIFY_INCONCLUSIVE` | Error | All classification tiers failed -- router returns fail-closed result |
+| `E_PARSE_CORRUPT` | Error | All parsers failed for file -- router returns error result |
+| `E_PARSE_PASSWORD` | Error | Password-protected file -- from parser chain |
+| `E_PARSE_EMPTY` | Error | Empty file or no data sheets -- from parser chain |
+| `W_PARSER_FALLBACK` | Warning | Parser fell back (non-fatal) -- from parser chain |
+| `E_LLM_TIMEOUT` | Error | LLM backend timed out -- from LLMClassifier |
+| `E_LLM_MALFORMED_JSON` | Error | LLM returned bad JSON -- from LLMClassifier |
+| `E_LLM_SCHEMA_INVALID` | Error | LLM output failed validation -- from LLMClassifier |
+| `W_LLM_RETRY` | Warning | LLM retry attempt -- from LLMClassifier |
+
+---
+
+## Current Exports (__init__.py)
+
+The `__init__.py` already exports:
+- All 6 backend classes (SQLiteStructuredDB, QdrantVectorStore, OllamaLLM, OllamaEmbedding, MilvusVectorStore, PostgresStructuredDB)
+- `ExcelProcessorConfig`
+- `ErrorCode`, `IngestError`
+- `compute_ingest_key`
+- All models: ChunkMetadata, ChunkPayload, ClassificationResult, ClassificationStageResult, ClassificationTier, EmbedStageResult, FileProfile, FileType, IngestKey, IngestionMethod, ParseStageResult, ParserUsed, ProcessingResult, RegionType, SheetProfile, SheetRegion, WrittenArtifacts
+- `ExcelInspector`, `LLMClassifier`, `ParserChain`
+- `StructuredDBProcessor`, `TextSerializer`, `HybridSplitter`
+- All 4 protocol types
+
+**Missing (to be added):**
+- `ExcelRouter` (from `ingestkit_excel.router`)
+- `create_default_router` (function -- can live in `router.py` or `__init__.py`)
+
+---
+
+## Key Patterns (From Existing Code)
+
+1. **Logger name**: All modules use `logger = logging.getLogger("ingestkit_excel")` (except processors which use `__name__` -- the router MUST use `"ingestkit_excel"` per SPEC section 15).
+
+2. **Config defaults**: Constructor accepts `config: ExcelProcessorConfig | None = None` -- if None, create a default instance.
+
+3. **Error collection pattern**: All modules collect `list[IngestError]` during processing. The router should aggregate errors from all stages.
+
+4. **Fail-closed pattern**: When classification is inconclusive, return `ProcessingResult` with error code and zero chunks/tables. Never guess.
+
+5. **ProcessingResult assembly**: Processors already return complete `ProcessingResult` objects. For fail-closed cases (parse failure, classification inconclusive), the router needs to construct a minimal `ProcessingResult` itself.
+
+6. **Stage artifacts**: The router must construct:
+   - `ParseStageResult` from parse output (parser_used from the first sheet or most common parser, sheets_parsed, sheets_skipped, skipped_reasons, parse_duration_seconds)
+   - `ClassificationStageResult` from classification output (tier_used, file_type, confidence, signals, reasoning, per_sheet_types, classification_duration_seconds)
+   - Processors construct their own `ProcessingResult` including embed_result.
+
+7. **HybridSplitter construction**: Requires instances of StructuredDBProcessor and TextSerializer (not just their backends). The router creates all three processors upfront.
+
+8. **Time tracking**: Use `time.monotonic()` for duration measurements (consistent with existing code).
+
+9. **PII-safe INFO log format** (SPEC section 15):
+   ```
+   ingestkit_excel | file=X | ingest_key=X | tier=X | type=X | confidence=X | path=X | chunks=X | tables=X | parser=X | time=Xs
+   ```
+
+10. **Processor `ingest_key` param is a string**: Processors receive `ingest_key: str` (the hex digest from `IngestKey.key`), NOT the `IngestKey` model itself.
+
+---
+
+## Risks
+
+1. **ParseStageResult construction complexity**: The router must assemble `ParseStageResult` from `FileProfile` + `list[IngestError]`. This requires:
+   - Determining a "primary" `parser_used` from the sheet profiles (most common or first sheet's parser).
+   - Counting sheets_parsed vs sheets_skipped.
+   - Building `skipped_reasons` dict from warning errors.
+   - Measuring parse duration (separate timer in router).
+
+2. **Fail-closed ProcessingResult construction**: When parsing fails completely or classification is inconclusive, the router must construct a complete `ProcessingResult` with placeholder/empty values. This requires dummy `ParseStageResult` and `ClassificationStageResult` objects.
+
+3. **Tier escalation edge cases**:
+   - Tier 1 returns confidence=0.0 for inconclusive (escalate).
+   - Tier 1 returns confidence=0.7 for medium confidence -- SPEC says this does NOT escalate (only inconclusive escalates).
+   - Tier 1 returns HYBRID with confidence=0.9 when sheets disagree -- this is a valid classification, NOT inconclusive.
+   - LLMClassifier returns confidence=0.0 on failure -- must be treated as failure, not as a valid classification.
+
+4. **create_default_router needs concrete backend imports**: The factory function creates default instances of Qdrant, SQLite, Ollama backends. These are optional deps -- the function should handle ImportError gracefully or document the requirement.
+
+5. **Error aggregation**: Parse errors come from `ParserChain.parse()`, classification errors come internally from LLMClassifier (but are NOT returned separately -- they're absorbed into the ClassificationResult). Processing errors come from the processor's `ProcessingResult`. The router should merge parse-stage errors into the final result.
+
+6. **source_uri handling**: `process()` accepts optional `source_uri` which is passed to `compute_ingest_key()`. If None, the idempotency module derives it from the file path.
+
+7. **Logger consistency**: Processors use `logging.getLogger(__name__)` but the SPEC requires `"ingestkit_excel"`. The router itself must use `"ingestkit_excel"`. The processor logger names are an existing pattern that shouldn't be changed by this issue.
+
+AGENT_RETURN: map-12-021226.md

--- a/.agents/outputs/plan-12-021226.md
+++ b/.agents/outputs/plan-12-021226.md
@@ -1,0 +1,890 @@
+# PLAN -- Issue #12: ExcelRouter Orchestrator and Public API
+
+---
+issue: 12
+agent: PLAN
+date: 2026-02-12
+complexity: COMPLEX
+stack: backend
+---
+
+## Executive Summary
+
+ExcelRouter is the top-level orchestrator that wires together ParserChain, ExcelInspector, LLMClassifier, and all three processors (StructuredDBProcessor, TextSerializer, HybridSplitter) into a single `process()` call. The router handles ingest key computation, tier escalation logic, fail-closed error handling, PII-safe logging, and stage artifact construction. A `create_default_router()` factory provides a zero-config entry point. Two files are created: `router.py` and `tests/test_router.py`, plus updates to `__init__.py`.
+
+---
+
+## 1. `router.py` -- Complete Class Outline
+
+**File:** `packages/ingestkit-excel/src/ingestkit_excel/router.py`
+
+```python
+"""ExcelRouter: top-level orchestrator for the ingestkit-excel pipeline.
+
+Wires together the parser chain, tiered classification, and processing
+paths into a single ``process()`` call.  Handles ingest key computation,
+tier escalation, fail-closed error handling, and PII-safe logging.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+import uuid
+
+from ingestkit_excel.config import ExcelProcessorConfig
+from ingestkit_excel.errors import ErrorCode, IngestError
+from ingestkit_excel.idempotency import compute_ingest_key
+from ingestkit_excel.inspector import ExcelInspector
+from ingestkit_excel.llm_classifier import LLMClassifier
+from ingestkit_excel.models import (
+    ClassificationResult,
+    ClassificationStageResult,
+    ClassificationTier,
+    FileProfile,
+    FileType,
+    IngestionMethod,
+    ParseStageResult,
+    ParserUsed,
+    ProcessingResult,
+    WrittenArtifacts,
+)
+from ingestkit_excel.parser_chain import ParserChain
+from ingestkit_excel.processors import (
+    HybridSplitter,
+    StructuredDBProcessor,
+    TextSerializer,
+)
+from ingestkit_excel.protocols import (
+    EmbeddingBackend,
+    LLMBackend,
+    StructuredDBBackend,
+    VectorStoreBackend,
+)
+
+logger = logging.getLogger("ingestkit_excel")
+
+
+class ExcelRouter:
+    """Top-level orchestrator for Excel file ingestion.
+
+    Parameters
+    ----------
+    vector_store : VectorStoreBackend
+    structured_db : StructuredDBBackend
+    llm : LLMBackend
+    embedder : EmbeddingBackend
+    config : ExcelProcessorConfig | None
+        If None, uses ExcelProcessorConfig() defaults.
+    """
+
+    def __init__(
+        self,
+        vector_store: VectorStoreBackend,
+        structured_db: StructuredDBBackend,
+        llm: LLMBackend,
+        embedder: EmbeddingBackend,
+        config: ExcelProcessorConfig | None = None,
+    ) -> None:
+        self._config = config or ExcelProcessorConfig()
+        self._vector_store = vector_store
+        self._structured_db = structured_db
+        self._llm = llm
+        self._embedder = embedder
+
+        # Build pipeline components
+        self._parser = ParserChain(self._config)
+        self._inspector = ExcelInspector(self._config)
+        self._llm_classifier = LLMClassifier(self._llm, self._config)
+
+        # Build processors (all three upfront)
+        self._structured_processor = StructuredDBProcessor(
+            self._structured_db, self._vector_store, self._embedder, self._config
+        )
+        self._text_serializer = TextSerializer(
+            self._vector_store, self._embedder, self._config
+        )
+        self._hybrid_splitter = HybridSplitter(
+            self._structured_processor, self._text_serializer, self._config
+        )
+
+    # -- public API --
+
+    def process(
+        self, file_path: str, source_uri: str | None = None
+    ) -> ProcessingResult:
+        """Classify and process a single Excel file."""
+        ...  # See section 2
+
+    def process_batch(
+        self, file_paths: list[str]
+    ) -> list[ProcessingResult]:
+        """Process multiple files sequentially."""
+        ...  # Simple loop over process()
+
+    # -- private helpers --
+
+    def _build_parse_stage_result(
+        self,
+        profile: FileProfile,
+        parse_errors: list[IngestError],
+        parse_duration: float,
+    ) -> ParseStageResult:
+        """Construct ParseStageResult from parse output."""
+        ...  # See section 4
+
+    def _build_classification_stage_result(
+        self,
+        classification: ClassificationResult,
+        classification_duration: float,
+    ) -> ClassificationStageResult:
+        """Construct ClassificationStageResult from classification output."""
+        ...  # See section 5
+
+    def _build_fail_closed_result(
+        self,
+        file_path: str,
+        ingest_key: str,
+        ingest_run_id: str,
+        parse_result: ParseStageResult,
+        classification_result: ClassificationStageResult,
+        classification: ClassificationResult,
+        errors: list[str],
+        warnings: list[str],
+        error_details: list[IngestError],
+        elapsed: float,
+    ) -> ProcessingResult:
+        """Build a fail-closed ProcessingResult with zero output."""
+        ...  # See section 6
+
+    def _log_result(
+        self, file_path: str, result: ProcessingResult
+    ) -> None:
+        """Emit PII-safe INFO log for the processing result."""
+        ...  # See section 7
+
+
+def create_default_router(**overrides) -> ExcelRouter:
+    """Create a router with default backends (Qdrant, SQLite, Ollama)."""
+    ...  # See section 8
+```
+
+---
+
+## 2. `process()` Flow -- Step-by-Step with Error Handling
+
+```python
+def process(
+    self, file_path: str, source_uri: str | None = None
+) -> ProcessingResult:
+    overall_start = time.monotonic()
+    config = self._config
+    errors: list[str] = []
+    warnings: list[str] = []
+    error_details: list[IngestError] = []
+
+    # ---- Step 1: Compute ingest key ----
+    ingest_key_obj = compute_ingest_key(
+        file_path=file_path,
+        parser_version=config.parser_version,
+        tenant_id=config.tenant_id,
+        source_uri=source_uri,
+    )
+    ingest_key = ingest_key_obj.key  # SHA-256 hex digest string
+    ingest_run_id = str(uuid.uuid4())
+
+    # ---- Step 2: Parse ----
+    parse_start = time.monotonic()
+    profile, parse_errors = self._parser.parse(file_path)
+    parse_duration = time.monotonic() - parse_start
+
+    # Collect parse warnings/errors into result lists
+    for err in parse_errors:
+        if err.code.value.startswith("W_"):
+            warnings.append(err.code.value)
+        else:
+            errors.append(err.code.value)
+        error_details.append(err)
+
+    # Build ParseStageResult
+    parse_result = self._build_parse_stage_result(
+        profile, parse_errors, parse_duration
+    )
+
+    # ---- Step 2a: Check for fatal parse failure ----
+    # If no sheets parsed AND there are fatal errors, return fail-closed
+    has_fatal_parse = any(
+        not err.recoverable for err in parse_errors
+    )
+    if profile.sheet_count == 0 and has_fatal_parse:
+        # Build a dummy classification result for fail-closed
+        classification = ClassificationResult(
+            file_type=FileType.HYBRID,
+            confidence=0.0,
+            tier_used=ClassificationTier.RULE_BASED,
+            reasoning="Parse failed: no sheets available for classification.",
+            per_sheet_types=None,
+            signals=None,
+        )
+        classification_stage = self._build_classification_stage_result(
+            classification, 0.0
+        )
+        elapsed = time.monotonic() - overall_start
+        result = self._build_fail_closed_result(
+            file_path=file_path,
+            ingest_key=ingest_key,
+            ingest_run_id=ingest_run_id,
+            parse_result=parse_result,
+            classification_result=classification_stage,
+            classification=classification,
+            errors=errors,
+            warnings=warnings,
+            error_details=error_details,
+            elapsed=elapsed,
+        )
+        self._log_result(file_path, result)
+        return result
+
+    # ---- Step 3: Tier 1 Classification (Inspector) ----
+    classify_start = time.monotonic()
+    classification = self._inspector.classify(profile)
+
+    # ---- Step 4: Tier Escalation ----
+    # Tier 1 inconclusive: confidence == 0.0
+    if classification.confidence == 0.0:
+        logger.info(
+            "Tier 1 inconclusive for %s, escalating to Tier 2",
+            os.path.basename(file_path),
+        )
+        classification = self._llm_classifier.classify(
+            profile, ClassificationTier.LLM_BASIC
+        )
+
+    # Tier 2 low confidence: confidence < tier2_confidence_threshold
+    # AND enable_tier3 is True
+    if (
+        classification.confidence < config.tier2_confidence_threshold
+        and classification.confidence > 0.0  # 0.0 means LLM failure
+        and config.enable_tier3
+    ):
+        logger.info(
+            "Tier 2 confidence %.2f below threshold %.2f for %s, escalating to Tier 3",
+            classification.confidence,
+            config.tier2_confidence_threshold,
+            os.path.basename(file_path),
+        )
+        classification = self._llm_classifier.classify(
+            profile, ClassificationTier.LLM_REASONING
+        )
+
+    # Also check: if Tier 2 returned confidence==0.0 (LLM failure),
+    # escalate to Tier 3 if enabled
+    if classification.confidence == 0.0 and config.enable_tier3 and classification.tier_used == ClassificationTier.LLM_BASIC:
+        logger.info(
+            "Tier 2 failed for %s, escalating to Tier 3",
+            os.path.basename(file_path),
+        )
+        classification = self._llm_classifier.classify(
+            profile, ClassificationTier.LLM_REASONING
+        )
+
+    classify_duration = time.monotonic() - classify_start
+
+    classification_stage = self._build_classification_stage_result(
+        classification, classify_duration
+    )
+
+    # ---- Step 5: Fail-closed check ----
+    if classification.confidence == 0.0:
+        logger.error(
+            "All classification tiers failed for %s -- fail-closed",
+            os.path.basename(file_path),
+        )
+        errors.append(ErrorCode.E_CLASSIFY_INCONCLUSIVE.value)
+        error_details.append(
+            IngestError(
+                code=ErrorCode.E_CLASSIFY_INCONCLUSIVE,
+                message="All classification tiers exhausted. Fail-closed.",
+                stage="classify",
+                recoverable=False,
+            )
+        )
+        elapsed = time.monotonic() - overall_start
+        result = self._build_fail_closed_result(
+            file_path=file_path,
+            ingest_key=ingest_key,
+            ingest_run_id=ingest_run_id,
+            parse_result=parse_result,
+            classification_result=classification_stage,
+            classification=classification,
+            errors=errors,
+            warnings=warnings,
+            error_details=error_details,
+            elapsed=elapsed,
+        )
+        self._log_result(file_path, result)
+        return result
+
+    # ---- Step 6: Route to processor ----
+    processor_args = dict(
+        file_path=file_path,
+        profile=profile,
+        ingest_key=ingest_key,
+        ingest_run_id=ingest_run_id,
+        parse_result=parse_result,
+        classification_result=classification_stage,
+        classification=classification,
+    )
+
+    if classification.file_type == FileType.TABULAR_DATA:
+        result = self._structured_processor.process(**processor_args)
+    elif classification.file_type == FileType.FORMATTED_DOCUMENT:
+        result = self._text_serializer.process(**processor_args)
+    else:  # HYBRID
+        result = self._hybrid_splitter.process(**processor_args)
+
+    # ---- Step 7: Merge parse-stage errors/warnings into result ----
+    # Processors build their own errors/warnings from their stage.
+    # We prepend parse-stage errors/warnings that the router collected.
+    result_errors = errors + result.errors
+    result_warnings = warnings + result.warnings
+    result_error_details = error_details + result.error_details
+
+    # Replace total processing time with the full router time
+    elapsed = time.monotonic() - overall_start
+
+    # Rebuild result with merged errors and full timing
+    # Use model_copy to avoid reconstructing the entire object
+    result = result.model_copy(update={
+        "errors": result_errors,
+        "warnings": result_warnings,
+        "error_details": result_error_details,
+        "processing_time_seconds": elapsed,
+    })
+
+    # ---- Step 8: Log and return ----
+    self._log_result(file_path, result)
+    return result
+```
+
+### Key Design Decisions
+
+1. **Tier escalation from Tier 2 failure (confidence==0.0)**: The LLMClassifier returns confidence=0.0 on complete failure (all retries exhausted). This is DISTINCT from low confidence (e.g., 0.4). Both should escalate to Tier 3 if enabled, but through different code paths.
+
+2. **Error merging**: Parse-stage errors are collected by the router before the processor runs. Processor-stage errors are in the ProcessingResult returned by the processor. The router merges both sets, with parse errors prepended.
+
+3. **Timing**: `processing_time_seconds` in the final result covers the full router lifecycle (parse + classify + process), not just the processor's internal time.
+
+4. **model_copy()**: Use Pydantic v2's `model_copy(update={...})` to update the ProcessingResult fields without mutating the original or reconstructing from scratch.
+
+---
+
+## 3. Tier Escalation Logic -- Exact Conditions
+
+```
+Tier 1 (ExcelInspector):
+  - >= 4 signals same type -> confidence 0.9
+  - 3 signals same type -> confidence 0.7
+  - < 3 signals either way -> confidence 0.0 (INCONCLUSIVE)
+  - Sheets disagree -> HYBRID, confidence 0.9
+
+Escalation to Tier 2:
+  - IF classification.confidence == 0.0
+  - Call LLMClassifier.classify(profile, ClassificationTier.LLM_BASIC)
+
+Escalation to Tier 3:
+  - IF classification.confidence < config.tier2_confidence_threshold (0.6)
+    AND config.enable_tier3 is True
+  - OR IF Tier 2 returned confidence == 0.0 (complete LLM failure)
+    AND config.enable_tier3 is True
+  - Call LLMClassifier.classify(profile, ClassificationTier.LLM_REASONING)
+
+Fail-closed:
+  - IF final classification.confidence == 0.0
+  - Return ProcessingResult with E_CLASSIFY_INCONCLUSIVE, zero chunks/tables
+```
+
+**Important edge cases:**
+- Tier 1 returns confidence=0.7 (medium) -> does NOT escalate. Only confidence==0.0 escalates.
+- Tier 1 returns HYBRID with confidence=0.9 (sheets disagree) -> valid classification, NOT inconclusive.
+- Tier 2 returns confidence=0.5 (below threshold but > 0) -> escalate to Tier 3.
+- Tier 2 returns confidence=0.0 (LLM failure) -> escalate to Tier 3 (if enabled).
+- Tier 3 returns confidence=0.0 -> fail-closed.
+- `enable_tier3=False` -> skip Tier 3, if Tier 2 confidence < threshold AND > 0, ACCEPT the Tier 2 result. If Tier 2 confidence == 0.0, fail-closed.
+
+**Correction to initial logic**: When `enable_tier3=False` and Tier 2 has low confidence (> 0 but < threshold), we should still ACCEPT the result rather than fail-closed. The fail-closed condition is strictly `confidence == 0.0` which means classification completely failed. A low but nonzero confidence is still a valid classification.
+
+Revised fail-closed check:
+```python
+# Fail-closed: only when confidence is exactly 0.0 (meaning all tiers FAILED)
+if classification.confidence == 0.0:
+    # fail-closed
+```
+
+---
+
+## 4. ParseStageResult Construction
+
+```python
+def _build_parse_stage_result(
+    self,
+    profile: FileProfile,
+    parse_errors: list[IngestError],
+    parse_duration: float,
+) -> ParseStageResult:
+    """Construct ParseStageResult from FileProfile + parse errors."""
+    # Determine primary parser_used: most common among sheets, or OPENPYXL if no sheets
+    if profile.sheets:
+        parser_counts: dict[ParserUsed, int] = {}
+        for sheet in profile.sheets:
+            parser_counts[sheet.parser_used] = parser_counts.get(sheet.parser_used, 0) + 1
+        primary_parser = max(parser_counts, key=parser_counts.get)
+    else:
+        primary_parser = ParserUsed.OPENPYXL
+
+    # Determine fallback_reason_code: if any sheet used a fallback parser
+    fallback_reason = None
+    for err in parse_errors:
+        if err.code == ErrorCode.W_PARSER_FALLBACK:
+            fallback_reason = err.code.value
+            break
+
+    # Count parsed vs skipped
+    sheets_parsed = len(profile.sheets)
+
+    # Skipped sheets: those with warning errors (chart, password, truncated, etc.)
+    skipped_reasons: dict[str, str] = {}
+    for err in parse_errors:
+        if err.sheet_name and err.code.value.startswith("W_"):
+            skipped_reasons[err.sheet_name] = err.code.value
+
+    sheets_skipped = len(skipped_reasons)
+
+    return ParseStageResult(
+        parser_used=primary_parser,
+        fallback_reason_code=fallback_reason,
+        sheets_parsed=sheets_parsed,
+        sheets_skipped=sheets_skipped,
+        skipped_reasons=skipped_reasons,
+        parse_duration_seconds=parse_duration,
+    )
+```
+
+---
+
+## 5. ClassificationStageResult Construction
+
+```python
+def _build_classification_stage_result(
+    self,
+    classification: ClassificationResult,
+    classification_duration: float,
+) -> ClassificationStageResult:
+    return ClassificationStageResult(
+        tier_used=classification.tier_used,
+        file_type=classification.file_type,
+        confidence=classification.confidence,
+        signals=classification.signals,
+        reasoning=classification.reasoning,
+        per_sheet_types=classification.per_sheet_types,
+        classification_duration_seconds=classification_duration,
+    )
+```
+
+---
+
+## 6. Fail-Closed Handling
+
+When parsing fails completely or classification is inconclusive, the router constructs a minimal `ProcessingResult`:
+
+```python
+def _build_fail_closed_result(
+    self,
+    file_path: str,
+    ingest_key: str,
+    ingest_run_id: str,
+    parse_result: ParseStageResult,
+    classification_result: ClassificationStageResult,
+    classification: ClassificationResult,
+    errors: list[str],
+    warnings: list[str],
+    error_details: list[IngestError],
+    elapsed: float,
+) -> ProcessingResult:
+    return ProcessingResult(
+        file_path=file_path,
+        ingest_key=ingest_key,
+        ingest_run_id=ingest_run_id,
+        tenant_id=self._config.tenant_id,
+        parse_result=parse_result,
+        classification_result=classification_result,
+        embed_result=None,
+        classification=classification,
+        ingestion_method=IngestionMethod.SQL_AGENT,  # arbitrary, since no processing occurs
+        chunks_created=0,
+        tables_created=0,
+        tables=[],
+        written=WrittenArtifacts(),
+        errors=errors,
+        warnings=warnings,
+        error_details=error_details,
+        processing_time_seconds=elapsed,
+    )
+```
+
+**Key properties of a fail-closed result:**
+- `chunks_created=0`, `tables_created=0`, `tables=[]`
+- `written=WrittenArtifacts()` (empty -- no vector_collection, no ids)
+- `embed_result=None`
+- `errors` contains the relevant error code string (e.g. `"E_CLASSIFY_INCONCLUSIVE"` or `"E_PARSE_CORRUPT"`)
+- `error_details` contains structured `IngestError` objects
+- `ingestion_method` is set to `SQL_AGENT` as a default (the spec doesn't specify a particular value for fail-closed; any valid enum member works since no processing actually occurs)
+
+---
+
+## 7. PII-Safe Logging
+
+```python
+def _log_result(self, file_path: str, result: ProcessingResult) -> None:
+    """Emit PII-safe INFO log matching SPEC section 15 format."""
+    filename = os.path.basename(file_path)
+
+    # Determine primary parser for log
+    parser_str = result.parse_result.parser_used.value
+
+    logger.info(
+        "file=%s | ingest_key=%.8s | tier=%s | type=%s | confidence=%s "
+        "| path=%s | chunks=%d | tables=%d | parser=%s | time=%.1fs",
+        filename,
+        result.ingest_key,
+        result.classification_result.tier_used.value,
+        result.classification_result.file_type.value,
+        result.classification_result.confidence,
+        result.ingestion_method.value,
+        result.chunks_created,
+        result.tables_created,
+        parser_str,
+        result.processing_time_seconds,
+    )
+```
+
+**PII-safe by design:**
+- Only filename (not full path) in logs
+- Ingest key truncated to first 8 chars
+- No raw cell data, no sample rows, no LLM prompts
+- Config flags `log_sample_data`, `log_llm_prompts`, `log_chunk_previews` are handled by the individual components (parser, classifier, processors), not the router itself
+
+---
+
+## 8. `create_default_router()` Factory
+
+```python
+def create_default_router(**overrides) -> ExcelRouter:
+    """Create a router with default backends (Qdrant, SQLite, Ollama).
+
+    Accepts any ExcelProcessorConfig field as a keyword override.
+    Requires qdrant-client and httpx to be installed.
+
+    Parameters
+    ----------
+    **overrides
+        Keyword arguments passed to ExcelProcessorConfig().
+
+    Returns
+    -------
+    ExcelRouter
+        A fully configured router with default backends.
+    """
+    config = ExcelProcessorConfig(**overrides)
+
+    # Import concrete backends (may raise ImportError if deps missing)
+    from ingestkit_excel.backends.qdrant import QdrantVectorStore
+    from ingestkit_excel.backends.sqlite import SQLiteStructuredDB
+    from ingestkit_excel.backends.ollama import OllamaLLM, OllamaEmbedding
+
+    vector_store = QdrantVectorStore()
+    structured_db = SQLiteStructuredDB()
+    llm = OllamaLLM()
+    embedder = OllamaEmbedding(
+        model=config.embedding_model,
+    )
+
+    return ExcelRouter(
+        vector_store=vector_store,
+        structured_db=structured_db,
+        llm=llm,
+        embedder=embedder,
+        config=config,
+    )
+```
+
+**Notes:**
+- Imports are inside the function body so the factory fails gracefully if optional deps are missing, without affecting the rest of the module.
+- Uses default constructor args for each backend (see backends for signatures).
+- The `**overrides` pattern lets callers customize config without constructing it themselves: `create_default_router(tenant_id="acme", classification_model="llama3:8b")`.
+
+---
+
+## 9. `process_batch()` Implementation
+
+```python
+def process_batch(
+    self, file_paths: list[str]
+) -> list[ProcessingResult]:
+    """Process multiple files sequentially.
+
+    Each file is processed independently. Failures in one file
+    do not affect others.
+    """
+    results: list[ProcessingResult] = []
+    for file_path in file_paths:
+        try:
+            result = self.process(file_path)
+            results.append(result)
+        except Exception as exc:
+            # If process() itself raises (e.g., FileNotFoundError from
+            # compute_ingest_key), log and continue
+            logger.error(
+                "Failed to process %s: %s",
+                os.path.basename(file_path),
+                exc,
+            )
+            # We cannot build a full ProcessingResult without parsing,
+            # so we re-raise to let the caller handle it.
+            # ALTERNATIVE: wrap in a try/except within process() so it
+            # never raises. But FileNotFoundError from compute_ingest_key
+            # is a valid exception the caller should handle.
+            raise
+    return results
+```
+
+**Design decision**: `process_batch()` does NOT swallow exceptions from `process()`. If `process()` raises (e.g., `FileNotFoundError`), it propagates to the caller. The `process()` method itself should handle all recoverable errors internally and return a `ProcessingResult` -- only truly unrecoverable scenarios (file not found, etc.) should raise.
+
+**However**, per SPEC the parser chain raises `FileNotFoundError`. The router's `process()` should catch this and return a fail-closed result. Let me revise:
+
+In `process()`, wrap the entire flow in a try/except to catch `FileNotFoundError` from `compute_ingest_key` or `parse()`:
+
+```python
+def process(self, file_path: str, source_uri: str | None = None) -> ProcessingResult:
+    overall_start = time.monotonic()
+    try:
+        return self._process_impl(file_path, source_uri, overall_start)
+    except FileNotFoundError:
+        logger.error("File not found: %s", file_path)
+        raise  # Re-raise -- caller must handle missing files
+    except Exception as exc:
+        logger.exception("Unexpected error processing %s: %s", file_path, exc)
+        raise
+```
+
+Actually, `FileNotFoundError` should propagate to the caller since the file literally doesn't exist. The router should not fabricate a ProcessingResult for a non-existent file (no content_hash, no ingest_key). So `process_batch()` should handle this:
+
+```python
+def process_batch(self, file_paths: list[str]) -> list[ProcessingResult]:
+    results: list[ProcessingResult] = []
+    for file_path in file_paths:
+        result = self.process(file_path)
+        results.append(result)
+    return results
+```
+
+Keep it simple -- just a sequential loop. If one file raises, the exception propagates. The caller can wrap in their own try/except if they want to continue on failure.
+
+---
+
+## 10. `tests/test_router.py` -- Test Plan
+
+**File:** `packages/ingestkit-excel/tests/test_router.py`
+
+### Mock Backends (reuse from test_structured_db.py pattern)
+
+```python
+class MockStructuredDB:  # same as test_structured_db.py
+class MockVectorStore:   # same as test_structured_db.py
+class MockEmbedder:      # same as test_structured_db.py
+class MockLLM:           # same as test_llm_classifier.py pattern
+```
+
+### Helper Factories
+
+```python
+def _make_sheet_profile(**overrides) -> SheetProfile: ...
+def _make_file_profile(sheets, **overrides) -> FileProfile: ...
+```
+
+### Test Classes
+
+#### `TestRouterConstruction`
+- `test_router_default_config` -- config=None uses defaults
+- `test_router_custom_config` -- custom config passed through
+- `test_router_creates_all_components` -- parser, inspector, classifier, 3 processors exist
+
+#### `TestProcessHappyPath` (mock ParserChain.parse and pd.read_excel)
+- `test_process_tabular_file` -- Tier 1 classifies as TABULAR_DATA, routes to Path A
+- `test_process_formatted_document` -- Tier 1 classifies as FORMATTED_DOCUMENT, routes to Path B
+- `test_process_hybrid_file` -- Tier 1 classifies as HYBRID, routes to Path C
+- `test_process_returns_correct_ingest_key` -- verify ingest_key in result matches computed key
+- `test_process_returns_correct_ingest_run_id` -- UUID4 format
+- `test_process_returns_correct_tenant_id` -- from config
+- `test_process_result_has_parse_result` -- ParseStageResult populated
+- `test_process_result_has_classification_result` -- ClassificationStageResult populated
+- `test_process_result_processing_time` -- processing_time_seconds > 0
+
+#### `TestTierEscalation` (mock inspector and LLM classifier)
+- `test_tier1_conclusive_no_escalation` -- Tier 1 confidence=0.9, no LLM calls
+- `test_tier1_medium_confidence_no_escalation` -- Tier 1 confidence=0.7, no LLM calls
+- `test_tier1_inconclusive_escalates_to_tier2` -- confidence=0.0 triggers Tier 2
+- `test_tier2_high_confidence_accepted` -- Tier 2 confidence=0.8, no Tier 3
+- `test_tier2_low_confidence_escalates_to_tier3` -- Tier 2 confidence=0.4 triggers Tier 3
+- `test_tier2_failure_escalates_to_tier3` -- Tier 2 confidence=0.0 (LLM failure) triggers Tier 3
+- `test_tier3_disabled_no_escalation` -- enable_tier3=False, Tier 2 low confidence accepted
+- `test_tier3_disabled_tier2_failure_fail_closed` -- enable_tier3=False, Tier 2 confidence=0.0 -> fail-closed
+- `test_all_tiers_fail_returns_fail_closed` -- Tier 1 + 2 + 3 all confidence=0.0
+
+#### `TestFailClosed`
+- `test_fail_closed_has_zero_chunks` -- chunks_created=0
+- `test_fail_closed_has_zero_tables` -- tables_created=0
+- `test_fail_closed_has_empty_written` -- WrittenArtifacts is empty
+- `test_fail_closed_has_inconclusive_error` -- E_CLASSIFY_INCONCLUSIVE in errors
+- `test_fail_closed_has_error_details` -- structured IngestError present
+- `test_fail_closed_embed_result_is_none` -- embed_result=None
+
+#### `TestParseFailure` (mock parser to return empty profile with errors)
+- `test_parse_failure_returns_fail_closed` -- empty profile + fatal error -> fail-closed
+- `test_parse_empty_file` -- E_PARSE_EMPTY in errors
+- `test_parse_corrupt_file` -- E_PARSE_CORRUPT in errors
+- `test_parse_password_protected` -- E_PARSE_PASSWORD in errors
+- `test_parse_warnings_in_result` -- W_PARSER_FALLBACK in warnings
+
+#### `TestParseStageResult`
+- `test_parse_stage_primary_parser` -- most common parser selected
+- `test_parse_stage_fallback_reason` -- W_PARSER_FALLBACK recorded
+- `test_parse_stage_sheets_parsed_count` -- matches sheet count
+- `test_parse_stage_sheets_skipped_count` -- skipped sheets counted
+- `test_parse_stage_skipped_reasons` -- dict populated for skipped sheets
+- `test_parse_stage_duration` -- > 0
+
+#### `TestClassificationStageResult`
+- `test_classification_stage_fields` -- all fields populated from ClassificationResult
+- `test_classification_stage_duration` -- > 0
+
+#### `TestErrorMerging`
+- `test_parse_errors_merged_into_result` -- parse errors + processor errors combined
+- `test_parse_warnings_merged_into_result` -- parse warnings + processor warnings combined
+- `test_error_details_merged` -- error_details from both stages merged
+
+#### `TestPIISafeLogging`
+- `test_info_log_emitted` -- caplog check for INFO level message
+- `test_info_log_contains_filename` -- only basename, not full path
+- `test_info_log_contains_truncated_key` -- first 8 chars only
+- `test_info_log_no_raw_data` -- no sample rows or cell values in log
+
+#### `TestProcessBatch`
+- `test_process_batch_returns_list` -- list of ProcessingResult
+- `test_process_batch_processes_all_files` -- one result per file
+- `test_process_batch_empty_list` -- empty input returns empty output
+
+#### `TestSourceUri`
+- `test_process_with_source_uri` -- custom source_uri passed to compute_ingest_key
+- `test_process_without_source_uri` -- source_uri=None uses default derivation
+
+#### `TestCreateDefaultRouter`
+- `test_create_default_router_returns_router` -- returns ExcelRouter instance
+- `test_create_default_router_with_overrides` -- config overrides applied
+- `test_create_default_router_missing_deps` -- ImportError if qdrant-client not installed
+
+### Mocking Strategy
+
+The tests should mock at the right level:
+1. **ParserChain.parse**: Mock to return pre-built FileProfile and IngestError lists
+2. **ExcelInspector.classify**: Mock to return pre-built ClassificationResult
+3. **LLMClassifier.classify**: Mock to return pre-built ClassificationResult
+4. **Processor.process**: Mock to return pre-built ProcessingResult
+5. **compute_ingest_key**: Mock to return pre-built IngestKey
+
+Use `unittest.mock.patch` on the class methods or module-level functions. Example:
+
+```python
+@patch("ingestkit_excel.router.compute_ingest_key")
+@patch.object(ParserChain, "parse")
+@patch.object(ExcelInspector, "classify")
+def test_process_tabular_file(
+    self, mock_inspector_classify, mock_parse, mock_compute_key,
+    router, mock_db, mock_vector_store, mock_embedder,
+):
+    # Setup mocks
+    mock_compute_key.return_value = IngestKey(
+        content_hash="a" * 64,
+        source_uri="file:///tmp/test.xlsx",
+        parser_version="ingestkit_excel:1.0.0",
+    )
+    profile = _make_file_profile([_make_sheet_profile()])
+    mock_parse.return_value = (profile, [])
+    mock_inspector_classify.return_value = ClassificationResult(
+        file_type=FileType.TABULAR_DATA,
+        confidence=0.9,
+        tier_used=ClassificationTier.RULE_BASED,
+        reasoning="High consistency",
+    )
+    # ... mock pd.read_excel for the processor ...
+
+    result = router.process("/tmp/test.xlsx")
+
+    assert result.ingestion_method == IngestionMethod.SQL_AGENT
+    assert result.classification.file_type == FileType.TABULAR_DATA
+```
+
+---
+
+## 11. `__init__.py` Updates
+
+Add two new exports:
+
+```python
+from ingestkit_excel.router import ExcelRouter, create_default_router
+
+__all__ = [
+    # ... existing entries ...
+    # Router
+    "ExcelRouter",
+    "create_default_router",
+]
+```
+
+Place the import after the processors import and before the `__all__` list. Add the entries to the `__all__` list in the "Router" section (new section after "Processors").
+
+---
+
+## 12. Acceptance Criteria
+
+- [ ] `router.py` exists with `ExcelRouter` class and `create_default_router` function
+- [ ] `ExcelRouter.__init__` accepts (vector_store, structured_db, llm, embedder, config=None)
+- [ ] `process()` computes ingest_key, generates UUID4 run_id, parses, classifies, routes to processor
+- [ ] Tier escalation: Tier 1 inconclusive (conf=0.0) -> Tier 2 -> Tier 3 (if enabled)
+- [ ] Fail-closed: all tiers fail -> ProcessingResult with E_CLASSIFY_INCONCLUSIVE, 0 chunks/tables
+- [ ] Parse failure: empty profile with fatal errors -> fail-closed result
+- [ ] ParseStageResult correctly constructed from FileProfile metadata
+- [ ] ClassificationStageResult correctly constructed from ClassificationResult
+- [ ] Error merging: parse-stage errors + processor errors combined in final result
+- [ ] PII-safe INFO log emitted per SPEC section 15 format
+- [ ] `process_batch()` processes files sequentially
+- [ ] `create_default_router(**overrides)` creates router with default backends
+- [ ] `__init__.py` exports ExcelRouter and create_default_router
+- [ ] Logger uses `logging.getLogger("ingestkit_excel")` (NOT `__name__`)
+- [ ] All new code has unit tests in `tests/test_router.py`
+- [ ] No regressions in existing tests
+
+---
+
+## 13. File Summary
+
+| File | Action | Lines (est.) |
+|------|--------|-------------|
+| `packages/ingestkit-excel/src/ingestkit_excel/router.py` | CREATE | ~280 |
+| `packages/ingestkit-excel/tests/test_router.py` | CREATE | ~600 |
+| `packages/ingestkit-excel/src/ingestkit_excel/__init__.py` | EDIT | +5 |
+
+Total: ~885 lines of new code across 2 new files and 1 edit.
+
+AGENT_RETURN: plan-12-021226.md

--- a/.agents/outputs/plan-check-12-021226.md
+++ b/.agents/outputs/plan-check-12-021226.md
@@ -1,0 +1,292 @@
+# PLAN-CHECK -- Issue #12: ExcelRouter Orchestrator and Public API
+
+---
+issue: 12
+agent: PLAN-CHECK
+date: 2026-02-12
+plan_artifact: plan-12-021226.md
+status: PASS_WITH_NOTES
+---
+
+## Executive Summary
+
+Plan validated against actual codebase signatures. All requirement areas are covered. Three issues found: (1) `compute_ingest_key` signature in plan matches actual code, but plan accesses `.key` property correctly; (2) HybridSplitter constructor signature differs from what plan assumes -- plan passes `(self._structured_processor, self._text_serializer, self._config)` which matches actual `__init__(self, structured_processor: object, text_serializer: object, config)` exactly; (3) one minor scope note on `process_batch` -- plan self-corrects its error handling mid-document, final version is correct. Recommend proceeding to PATCH.
+
+---
+
+## 1. Requirement Coverage
+
+| Requirement (from Issue #12) | Plan Section | Status |
+|------------------------------|-------------|--------|
+| Constructor accepts 4 backends + config | Section 1, lines 82-94 | PASS |
+| `process()` 12-step flow | Section 2, full flow | PASS |
+| Step 1: compute ingest_key | Section 2, Step 1 | PASS |
+| Step 2: generate UUID4 run_id | Section 2, Step 1 (line 195) | PASS |
+| Step 3: parse via ParserChain | Section 2, Step 2 | PASS |
+| Step 4: classify via Inspector (Tier 1) | Section 2, Step 3 | PASS |
+| Step 5: Tier 2 escalation if inconclusive | Section 2, Step 4 | PASS |
+| Step 6: Tier 3 escalation if low confidence | Section 2, Step 4 | PASS |
+| Step 7: Fail-closed on all tiers fail | Section 2, Step 5 | PASS |
+| Step 8: Route to processor (3 paths) | Section 2, Step 6 | PASS |
+| Step 9: Collect WrittenArtifacts | Via processor returns | PASS |
+| Step 10: Assemble ProcessingResult | Section 2, Step 7 | PASS |
+| Step 11: PII-safe log | Section 7 | PASS |
+| Step 12: Return result | Section 2, Step 8 | PASS |
+| `process_batch()` | Section 9 | PASS |
+| `create_default_router()` | Section 8 | PASS |
+| Public exports in `__init__.py` | Section 11 | PASS |
+| PII-safe logging format | Section 7 | PASS |
+| Tier escalation edge cases | Section 3 | PASS |
+| Test plan | Section 10 | PASS |
+
+**Coverage: 20/20 requirements mapped.**
+
+---
+
+## 2. Scope Containment
+
+| File | Action | Allowed? |
+|------|--------|----------|
+| `src/ingestkit_excel/router.py` | CREATE | YES -- new module |
+| `tests/test_router.py` | CREATE | YES -- new test file |
+| `src/ingestkit_excel/__init__.py` | EDIT | YES -- add 2 exports |
+
+**No out-of-scope files. PASS.**
+
+---
+
+## 3. Pattern Pre-checks (Signature Verification)
+
+### 3a. `ParserChain.parse()` return type
+
+**Actual** (parser_chain.py:58):
+```python
+def parse(self, file_path: str) -> tuple[FileProfile, list[IngestError]]
+```
+
+**Plan usage** (Section 2, Step 2):
+```python
+profile, parse_errors = self._parser.parse(file_path)
+```
+
+**Verdict: PASS** -- Destructure matches `tuple[FileProfile, list[IngestError]]`.
+
+### 3b. `ExcelInspector.classify()` signature
+
+**Actual** (inspector.py:46):
+```python
+def classify(self, profile: FileProfile) -> ClassificationResult
+```
+
+**Plan usage** (Section 2, Step 3):
+```python
+classification = self._inspector.classify(profile)
+```
+
+**Verdict: PASS** -- Single argument `FileProfile`, returns `ClassificationResult`.
+
+### 3c. `LLMClassifier.classify()` signature
+
+**Actual** (llm_classifier.py:100-104):
+```python
+def classify(
+    self,
+    profile: FileProfile,
+    tier: ClassificationTier,
+) -> ClassificationResult
+```
+
+**Plan usage** (Section 2, Step 4):
+```python
+classification = self._llm_classifier.classify(profile, ClassificationTier.LLM_BASIC)
+classification = self._llm_classifier.classify(profile, ClassificationTier.LLM_REASONING)
+```
+
+**Verdict: PASS** -- Two positional args `(profile, tier)` match.
+
+### 3d. `compute_ingest_key()` signature
+
+**Actual** (ingestkit_core/idempotency.py:21-26):
+```python
+def compute_ingest_key(
+    file_path: str,
+    parser_version: str,
+    tenant_id: str | None = None,
+    source_uri: str | None = None,
+) -> IngestKey
+```
+
+**Plan usage** (Section 2, Step 1):
+```python
+ingest_key_obj = compute_ingest_key(
+    file_path=file_path,
+    parser_version=config.parser_version,
+    tenant_id=config.tenant_id,
+    source_uri=source_uri,
+)
+ingest_key = ingest_key_obj.key
+```
+
+**Verdict: PASS** -- All 4 kwargs match actual signature. `.key` property exists on `IngestKey` (ingestkit_core/models.py:52-57, returns SHA-256 hex digest).
+
+### 3e. Processor `process()` signatures
+
+All three processors share identical signatures:
+
+**Actual** (structured_db.py:105-114, serializer.py:86-95, splitter.py:88-97):
+```python
+def process(
+    self,
+    file_path: str,
+    profile: FileProfile,
+    ingest_key: str,
+    ingest_run_id: str,
+    parse_result: ParseStageResult,
+    classification_result: ClassificationStageResult,
+    classification: ClassificationResult,
+) -> ProcessingResult
+```
+
+**Plan usage** (Section 2, Step 6):
+```python
+processor_args = dict(
+    file_path=file_path,
+    profile=profile,
+    ingest_key=ingest_key,
+    ingest_run_id=ingest_run_id,
+    parse_result=parse_result,
+    classification_result=classification_result,
+    classification=classification,
+)
+result = self._structured_processor.process(**processor_args)
+```
+
+**Verdict: PASS** -- 7 kwargs match all three processor signatures exactly.
+
+### 3f. Processor constructor signatures
+
+**StructuredDBProcessor** (structured_db.py:89-99):
+```python
+def __init__(self, structured_db, vector_store, embedder, config)
+```
+
+**Plan** (Section 1, lines 102-104):
+```python
+self._structured_processor = StructuredDBProcessor(
+    self._structured_db, self._vector_store, self._embedder, self._config
+)
+```
+**Verdict: PASS**
+
+**TextSerializer** (serializer.py:72-80):
+```python
+def __init__(self, vector_store, embedder, config)
+```
+
+**Plan** (Section 1, lines 105-107):
+```python
+self._text_serializer = TextSerializer(
+    self._vector_store, self._embedder, self._config
+)
+```
+**Verdict: PASS**
+
+**HybridSplitter** (splitter.py:72-83):
+```python
+def __init__(self, structured_processor: object, text_serializer: object, config)
+```
+
+**Plan** (Section 1, lines 108-110):
+```python
+self._hybrid_splitter = HybridSplitter(
+    self._structured_processor, self._text_serializer, self._config
+)
+```
+**Verdict: PASS** -- Takes processor instances, not backends.
+
+---
+
+## 4. Wiring Check: `__init__.py` Exports
+
+**Current exports** (line 42): Already exports `ParserChain`, `ExcelInspector`, `LLMClassifier`, all three processors, `ExcelProcessorConfig`, all models, all protocols, all backends.
+
+**Plan adds** (Section 11):
+```python
+from ingestkit_excel.router import ExcelRouter, create_default_router
+```
+Plus `"ExcelRouter"` and `"create_default_router"` in `__all__`.
+
+**Current `__init__.py` line 5-6 comment**: Already says "Higher-level components (ExcelRouter, create_default_router) will be exported here once implemented in subsequent issues."
+
+**Verdict: PASS** -- Clean addition. No conflicts with existing exports. The placeholder comment should be removed when adding the actual imports.
+
+---
+
+## 5. Issues Found
+
+### Issue 1: `process_batch()` self-correction in plan (LOW)
+
+The plan presents three different versions of `process_batch()` in Section 9 (lines 630-692). The first version catches and re-raises, the second adds a try/except discussion, the third simplifies to a plain loop. The **final version** (lines 684-689) is correct: a simple sequential loop with no exception swallowing.
+
+**Risk**: PATCH implementer might use an earlier version from the plan.
+**Recommendation**: PATCH should use the FINAL version (plain loop, no try/except wrapping). Exceptions from `process()` propagate to caller.
+
+### Issue 2: Tier escalation condition overlap (LOW)
+
+The plan has two separate `if` blocks for Tier 2 -> Tier 3 escalation (lines 266-279 and 283-289). The first handles low confidence (0 < conf < threshold), the second handles Tier 2 complete failure (conf == 0.0). Both check `config.enable_tier3`.
+
+After the first `if` block runs (Tier 2 low confidence -> Tier 3), the second `if` block's condition `classification.confidence == 0.0 and classification.tier_used == ClassificationTier.LLM_BASIC` would NOT match because Tier 3 would have updated `classification`. This is correct but could be cleaner -- a single escalation chain with `elif` would be more readable. No functional issue.
+
+**Recommendation**: Consider refactoring to a single escalation chain in PATCH for clarity, but the plan's logic is functionally correct.
+
+### Issue 3: `enable_tier3=False` with Tier 2 failure (INFO)
+
+Plan Section 3 (lines 413-414) correctly states: "enable_tier3=False, Tier 2 confidence==0.0 -> fail-closed". The code at line 299 (`if classification.confidence == 0.0`) handles this correctly since Tier 3 won't run, the confidence stays 0.0, and the fail-closed check catches it.
+
+**Verdict: Correct. No action needed.**
+
+### Issue 4: `structured_db.py` logger uses `__name__` not `"ingestkit_excel"` (INFO)
+
+The plan's `router.py` correctly uses `logging.getLogger("ingestkit_excel")`. However, `structured_db.py:35`, `serializer.py:34`, and `splitter.py:40` all use `logging.getLogger(__name__)` instead. This is not a plan issue but is worth noting -- the router's logging will be consistent with CLAUDE.md requirements even though the processors deviate.
+
+**No plan change needed.**
+
+---
+
+## 6. Model Field Verification
+
+**ProcessingResult fields used in fail-closed** (plan Section 6, verified against models.py:190-214):
+
+| Field | Plan Value | Model Type | Valid? |
+|-------|-----------|------------|--------|
+| `file_path` | from arg | `str` | YES |
+| `ingest_key` | SHA-256 hex | `str` | YES |
+| `ingest_run_id` | UUID4 str | `str` | YES |
+| `tenant_id` | from config | `str \| None` | YES |
+| `parse_result` | built | `ParseStageResult` | YES |
+| `classification_result` | built | `ClassificationStageResult` | YES |
+| `embed_result` | `None` | `EmbedStageResult \| None` | YES |
+| `classification` | built | `ClassificationResult` | YES |
+| `ingestion_method` | `IngestionMethod.SQL_AGENT` | `IngestionMethod` | YES |
+| `chunks_created` | `0` | `int` | YES |
+| `tables_created` | `0` | `int` | YES |
+| `tables` | `[]` | `list[str]` | YES |
+| `written` | `WrittenArtifacts()` | `WrittenArtifacts` | YES |
+| `errors` | list of strings | `list[str]` | YES |
+| `warnings` | list of strings | `list[str]` | YES |
+| `error_details` | list of IngestError | `list[IngestError]` | YES |
+| `processing_time_seconds` | float | `float` | YES |
+
+**All 17 fields verified. PASS.**
+
+---
+
+## 7. Verdict
+
+**PASS WITH NOTES**
+
+The plan is comprehensive, all signatures verified against actual code, scope is contained, and all 20 requirements are covered. Three minor notes for PATCH awareness (process_batch final version, escalation chain clarity, logger name convention) -- none are blockers.
+
+**Proceed to PATCH.**
+
+AGENT_RETURN: plan-check-12-021226.md

--- a/.agents/outputs/prove-12-021226.md
+++ b/.agents/outputs/prove-12-021226.md
@@ -1,0 +1,153 @@
+# PROVE: Issue #12 -- ExcelRouter Implementation
+
+**Date:** 2026-02-14
+**Branch:** feature/issue-12-excel-router
+**Verdict:** PASS
+
+---
+
+## Level 1: Tests
+
+### Router tests (test_router.py)
+```
+33 passed in 0.12s
+```
+- All 33 tests pass with zero failures or warnings.
+
+### Full test suite
+```
+546 passed in 1.64s
+```
+- Zero regressions. All 546 tests pass (513 pre-existing + 33 new).
+
+**CLAIM VERIFIED:** 33 new tests in test_router.py -- PASS
+**CLAIM VERIFIED:** 546 total tests passing (zero regressions) -- PASS
+
+---
+
+## Level 2: Imports
+
+```python
+from ingestkit_excel import ExcelRouter, create_default_router  # OK
+from ingestkit_excel.router import ExcelRouter, create_default_router  # OK
+```
+
+- Both `ExcelRouter` and `create_default_router` are exported from `__init__.py` (lines 41, 93-94).
+- Direct module import also works.
+
+**CLAIM VERIFIED:** ExcelRouter and create_default_router importable -- PASS
+
+---
+
+## Level 3: Acceptance Criteria
+
+### 12-step process flow (router.py process() method)
+
+| Step | Line(s) | Description | Verified |
+|------|---------|-------------|----------|
+| 1 | 146-152 | Compute deterministic IngestKey | YES |
+| 2 | 157 | Generate ingest_run_id (UUID4) | YES |
+| 3 | 162-164 | Parse via ParserChain | YES |
+| 4 | 169-171 | Build ParseStageResult from FileProfile | YES |
+| 5 | 174-181 | Log parse fallbacks as warnings | YES |
+| 6 | 186-218 | Classify with tiered escalation (Tier 1->2->3) | YES |
+| 7 | 225-282 | Fail-closed check (E_CLASSIFY_INCONCLUSIVE) | YES |
+| 8 | 287-295 | Build ClassificationStageResult from classification + timing | YES |
+| 9 | 308-309 | Route to processor (_select_processor) | YES |
+| 10 | 322-330 | Process via selected processor | YES |
+| 11 | 335 | Merge parse errors into processor result | YES |
+| 12 | 337-356 | Finalize timing and PII-safe INFO log | YES |
+
+### Tier escalation logic
+- Tier 1 inconclusive (confidence == 0.0) triggers Tier 2 (line 192-201)
+- Tier 2 below `config.tier2_confidence_threshold` triggers Tier 3 (line 203-218)
+- `config.enable_tier3` gate respected (line 206)
+- Tests: `TestTierEscalation` class covers all 4 scenarios (tier1->2, tier2->3, tier3 disabled, tier1 confident skips LLM)
+
+### Fail-closed semantics
+- confidence == 0.0 after all tiers returns ProcessingResult with:
+  - `chunks_created=0`, `tables_created=0`, `tables=[]`
+  - `ErrorCode.E_CLASSIFY_INCONCLUSIVE` in errors list
+  - `IngestError` with `recoverable=False` in error_details
+- Tests: `TestFailClosed` class with 2 tests covering structure and error codes
+
+### Batch processing
+- `process_batch()` (line 360-379) iterates sequentially, returns list in order
+- Tests: `TestProcessBatch` covers 3-file batch and empty list
+
+### PII-safe logging
+- Logger name: `"ingestkit_excel"` (line 52) -- correct
+- INFO logs use `filename` (basename only), truncated key (`ingest_key[:16]`), and aggregate counts -- no raw cell data
+- Test: `TestPIISafeLogging` validates INFO log contains truncated key
+
+### create_default_router() factory
+- Lines 472-553: Separates router kwargs from config kwargs, lazy-imports concrete backends
+- Tests: `TestCreateDefaultRouter` covers full override and config-kwarg passthrough
+
+### ParseStageResult from FileProfile
+- `_build_parse_stage_result()` (lines 386-425): Derives parser_used from first sheet, computes skipped reasons, fallback_reason_code
+- Tests: `TestBuildParseStageResult` with 5 tests (openpyxl, pandas fallback, raw_text fallback, skipped sheets, empty profile)
+
+### ClassificationStageResult from classification + timing
+- Built at lines 231-239 (fail path) and 287-295 (success path)
+- Captures tier_used, file_type, confidence, signals, reasoning, per_sheet_types, classification_duration_seconds
+- Test: `TestClassificationResultPropagation` validates all fields
+
+### Error merging
+- `_merge_parse_errors()` (lines 427-444): E_* codes go to errors list, W_* codes go to warnings list, all go to error_details
+- Tests: `TestParseErrorMerging` covers both warning and error merging
+
+**ALL ACCEPTANCE CRITERIA VERIFIED**
+
+---
+
+## Level 4: Code Quality
+
+### No hardcoded values
+- Threshold uses `config.tier2_confidence_threshold` (line 204)
+- `config.enable_tier3` gates Tier 3 (line 206)
+- `config.parser_version` and `config.tenant_id` used for ingest key (lines 149-150)
+- Only `0.0` literals are for the fail-closed sentinel check (inconclusive = confidence exactly 0.0), which is by design
+
+### Follows existing module patterns
+- Imports from same internal modules (models, errors, config, protocols)
+- Uses Protocol-typed backends (VectorStoreBackend, StructuredDBBackend, LLMBackend, EmbeddingBackend)
+- Returns Pydantic v2 models (ProcessingResult, ParseStageResult, etc.)
+- Uses `IngestError` with `ErrorCode` enum for structured errors
+- Dependency injection -- no concrete backends inside the core package
+
+### PII-safe logging
+- Logger name `"ingestkit_excel"` matches project convention
+- Logs only: filename (basename), truncated key (16 chars), tier, file_type, confidence, path name, chunk/table counts, timing
+- No raw cell data, no full file paths, no PII-bearing content logged
+
+### Files changed
+- **New:** `packages/ingestkit-excel/src/ingestkit_excel/router.py` (553 lines)
+- **New:** `packages/ingestkit-excel/tests/test_router.py` (1381 lines)
+- **Modified:** `packages/ingestkit-excel/src/ingestkit_excel/__init__.py` (+5/-3 lines -- added router exports)
+
+**CLAIM VERIFIED:** 2 files created, 1 modified -- PASS
+
+---
+
+## Summary
+
+| Claim | Status |
+|-------|--------|
+| 33 new tests in test_router.py | PASS |
+| 546 total tests passing (zero regressions) | PASS |
+| ExcelRouter and create_default_router importable | PASS |
+| 12-step process flow | PASS |
+| Tier escalation (1->2->3) with correct thresholds | PASS |
+| Fail-closed with E_CLASSIFY_INCONCLUSIVE | PASS |
+| Batch processing | PASS |
+| PII-safe logging | PASS |
+| create_default_router() factory | PASS |
+| ParseStageResult from FileProfile | PASS |
+| ClassificationStageResult built correctly | PASS |
+| Error merging (parse errors into result) | PASS |
+| No hardcoded values, uses config | PASS |
+| Follows existing module patterns | PASS |
+| 2 files created, 1 modified | PASS |
+
+**VERDICT: ALL CLAIMS VERIFIED -- PASS**

--- a/packages/ingestkit-excel/src/ingestkit_excel/__init__.py
+++ b/packages/ingestkit-excel/src/ingestkit_excel/__init__.py
@@ -1,9 +1,7 @@
 """ingestkit-excel -- Excel file ingestion plugin for the ingestkit framework.
 
 Public API exports for models, enums, errors, configuration, backend
-protocols, and concrete backend implementations.  Higher-level components
-(``ExcelRouter``, ``create_default_router``) will be exported here once
-implemented in subsequent issues.
+protocols, concrete backend implementations, and the top-level orchestrator.
 """
 
 from ingestkit_excel.backends import (
@@ -40,6 +38,7 @@ from ingestkit_excel.inspector import ExcelInspector
 from ingestkit_excel.llm_classifier import LLMClassifier
 from ingestkit_excel.parser_chain import ParserChain
 from ingestkit_excel.processors import HybridSplitter, StructuredDBProcessor, TextSerializer
+from ingestkit_excel.router import ExcelRouter, create_default_router
 from ingestkit_excel.protocols import (
     EmbeddingBackend,
     LLMBackend,
@@ -90,6 +89,9 @@ __all__ = [
     "StructuredDBBackend",
     "LLMBackend",
     "EmbeddingBackend",
+    # Router
+    "ExcelRouter",
+    "create_default_router",
     # Concrete backends
     "SQLiteStructuredDB",
     "QdrantVectorStore",

--- a/packages/ingestkit-excel/src/ingestkit_excel/router.py
+++ b/packages/ingestkit-excel/src/ingestkit_excel/router.py
@@ -1,0 +1,552 @@
+"""ExcelRouter -- orchestrator and public API for the ingestkit-excel pipeline.
+
+Routes Excel files through the full ingestion pipeline:
+
+1. Compute deterministic :class:`IngestKey` for deduplication.
+2. Parse via :class:`ParserChain` (three-tier per-sheet fallback).
+3. Classify via :class:`ExcelInspector` (Tier 1) with optional escalation to
+   :class:`LLMClassifier` (Tier 2/3).
+4. Route to the appropriate processor based on classification result.
+5. Return a fully-assembled :class:`ProcessingResult`.
+
+The router enforces **fail-closed** semantics: if classification is
+inconclusive after all tiers, it returns a ``ProcessingResult`` with
+``E_CLASSIFY_INCONCLUSIVE`` and zero chunks/tables.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+import uuid
+
+from ingestkit_excel.config import ExcelProcessorConfig
+from ingestkit_excel.errors import ErrorCode, IngestError
+from ingestkit_excel.idempotency import compute_ingest_key
+from ingestkit_excel.inspector import ExcelInspector
+from ingestkit_excel.llm_classifier import LLMClassifier
+from ingestkit_excel.models import (
+    ClassificationResult,
+    ClassificationStageResult,
+    ClassificationTier,
+    FileProfile,
+    FileType,
+    IngestionMethod,
+    ParseStageResult,
+    ParserUsed,
+    ProcessingResult,
+    WrittenArtifacts,
+)
+from ingestkit_excel.parser_chain import ParserChain
+from ingestkit_excel.processors.serializer import TextSerializer
+from ingestkit_excel.processors.splitter import HybridSplitter
+from ingestkit_excel.processors.structured_db import StructuredDBProcessor
+from ingestkit_excel.protocols import (
+    EmbeddingBackend,
+    LLMBackend,
+    StructuredDBBackend,
+    VectorStoreBackend,
+)
+
+logger = logging.getLogger("ingestkit_excel")
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+class ExcelRouter:
+    """Orchestrator that drives the full Excel ingestion pipeline.
+
+    Builds all internal components (parser chain, inspector, LLM classifier,
+    and the three processor paths) from the injected backends and config,
+    then exposes :meth:`process` and :meth:`process_batch` as the public API.
+
+    Parameters
+    ----------
+    vector_store:
+        Backend for vector storage (e.g. Qdrant).
+    structured_db:
+        Backend for structured/relational storage (e.g. SQLite).
+    llm:
+        Backend for LLM classification prompts.
+    embedder:
+        Backend for text embedding.
+    config:
+        Pipeline configuration. Uses defaults when *None*.
+    """
+
+    def __init__(
+        self,
+        vector_store: VectorStoreBackend,
+        structured_db: StructuredDBBackend,
+        llm: LLMBackend,
+        embedder: EmbeddingBackend,
+        config: ExcelProcessorConfig | None = None,
+    ) -> None:
+        self._config = config or ExcelProcessorConfig()
+
+        # Build internal pipeline components
+        self._parser_chain = ParserChain(self._config)
+        self._inspector = ExcelInspector(self._config)
+        self._llm_classifier = LLMClassifier(llm, self._config)
+
+        # Build processors
+        self._structured_db_processor = StructuredDBProcessor(
+            structured_db=structured_db,
+            vector_store=vector_store,
+            embedder=embedder,
+            config=self._config,
+        )
+        self._text_serializer = TextSerializer(
+            vector_store=vector_store,
+            embedder=embedder,
+            config=self._config,
+        )
+        self._hybrid_splitter = HybridSplitter(
+            structured_processor=self._structured_db_processor,
+            text_serializer=self._text_serializer,
+            config=self._config,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def process(
+        self,
+        file_path: str,
+        source_uri: str | None = None,
+    ) -> ProcessingResult:
+        """Process a single Excel file through the full ingestion pipeline.
+
+        Parameters
+        ----------
+        file_path:
+            Filesystem path to the ``.xlsx`` file.
+        source_uri:
+            Optional override for the source URI stored in the ingest key.
+            When *None*, the canonical absolute path is used.
+
+        Returns
+        -------
+        ProcessingResult
+            The fully-assembled result, including parse, classification,
+            embedding, and processing stage outputs.
+        """
+        overall_start = time.monotonic()
+        config = self._config
+        filename = os.path.basename(file_path)
+
+        # ----------------------------------------------------------
+        # Step 1: Compute ingest key
+        # ----------------------------------------------------------
+        ingest_key_obj = compute_ingest_key(
+            file_path=file_path,
+            parser_version=config.parser_version,
+            tenant_id=config.tenant_id,
+            source_uri=source_uri,
+        )
+        ingest_key = ingest_key_obj.key
+
+        # ----------------------------------------------------------
+        # Step 2: Generate ingest run ID
+        # ----------------------------------------------------------
+        ingest_run_id = str(uuid.uuid4())
+
+        # ----------------------------------------------------------
+        # Step 3: Parse
+        # ----------------------------------------------------------
+        parse_start = time.monotonic()
+        profile, parse_errors = self._parser_chain.parse(file_path)
+        parse_duration = time.monotonic() - parse_start
+
+        # ----------------------------------------------------------
+        # Step 4: Build ParseStageResult
+        # ----------------------------------------------------------
+        parse_result = self._build_parse_stage_result(
+            profile, parse_errors, parse_duration
+        )
+
+        # Log parse fallbacks as warnings
+        fallback_errors = [
+            e for e in parse_errors
+            if e.code == ErrorCode.W_PARSER_FALLBACK
+        ]
+        for fe in fallback_errors:
+            logger.warning(
+                "Parse fallback for %s: %s", filename, fe.message
+            )
+
+        # ----------------------------------------------------------
+        # Step 5: Classify (tiered escalation)
+        # ----------------------------------------------------------
+        classify_start = time.monotonic()
+
+        # Tier 1: Rule-based inspector
+        classification = self._inspector.classify(profile)
+        tier_used = ClassificationTier.RULE_BASED
+
+        if classification.confidence == 0.0:
+            # Escalate to Tier 2: LLM Basic
+            logger.warning(
+                "Tier 1 inconclusive for %s, escalating to Tier 2.",
+                filename,
+            )
+            classification = self._llm_classifier.classify(
+                profile, ClassificationTier.LLM_BASIC
+            )
+            tier_used = ClassificationTier.LLM_BASIC
+
+            if (
+                classification.confidence < config.tier2_confidence_threshold
+                and config.enable_tier3
+            ):
+                # Escalate to Tier 3: LLM Reasoning
+                logger.warning(
+                    "Tier 2 confidence %.2f < threshold %.2f for %s, "
+                    "escalating to Tier 3.",
+                    classification.confidence,
+                    config.tier2_confidence_threshold,
+                    filename,
+                )
+                classification = self._llm_classifier.classify(
+                    profile, ClassificationTier.LLM_REASONING
+                )
+                tier_used = ClassificationTier.LLM_REASONING
+
+        classify_duration = time.monotonic() - classify_start
+
+        # ----------------------------------------------------------
+        # Step 6: Fail-closed check
+        # ----------------------------------------------------------
+        if classification.confidence == 0.0:
+            logger.error(
+                "Classification inconclusive for %s after all tiers. "
+                "Returning fail-closed result.",
+                filename,
+            )
+            classification_result = ClassificationStageResult(
+                tier_used=tier_used,
+                file_type=classification.file_type,
+                confidence=0.0,
+                signals=classification.signals,
+                reasoning=classification.reasoning,
+                per_sheet_types=classification.per_sheet_types,
+                classification_duration_seconds=classify_duration,
+            )
+
+            elapsed = time.monotonic() - overall_start
+            fail_result = ProcessingResult(
+                file_path=file_path,
+                ingest_key=ingest_key,
+                ingest_run_id=ingest_run_id,
+                tenant_id=config.tenant_id,
+                parse_result=parse_result,
+                classification_result=classification_result,
+                embed_result=None,
+                classification=classification,
+                ingestion_method=IngestionMethod.SQL_AGENT,
+                chunks_created=0,
+                tables_created=0,
+                tables=[],
+                written=WrittenArtifacts(),
+                errors=[ErrorCode.E_CLASSIFY_INCONCLUSIVE.value],
+                warnings=[],
+                error_details=[
+                    IngestError(
+                        code=ErrorCode.E_CLASSIFY_INCONCLUSIVE,
+                        message="Classification inconclusive after all tiers. Fail-closed.",
+                        stage="classify",
+                        recoverable=False,
+                    )
+                ],
+                processing_time_seconds=elapsed,
+            )
+
+            # Merge parse errors into result
+            self._merge_parse_errors(fail_result, parse_errors)
+
+            logger.info(
+                "Processed %s: key=%s tier=%s type=%s confidence=%.2f "
+                "path=NONE chunks=0 tables=0 time=%.3fs",
+                filename,
+                ingest_key[:16],
+                tier_used.value,
+                classification.file_type.value,
+                classification.confidence,
+                elapsed,
+            )
+            return fail_result
+
+        # ----------------------------------------------------------
+        # Build ClassificationStageResult
+        # ----------------------------------------------------------
+        classification_result = ClassificationStageResult(
+            tier_used=tier_used,
+            file_type=classification.file_type,
+            confidence=classification.confidence,
+            signals=classification.signals,
+            reasoning=classification.reasoning,
+            per_sheet_types=classification.per_sheet_types,
+            classification_duration_seconds=classify_duration,
+        )
+
+        # Log classification escalations
+        if tier_used != ClassificationTier.RULE_BASED:
+            logger.warning(
+                "Classification for %s required escalation to %s.",
+                filename,
+                tier_used.value,
+            )
+
+        # ----------------------------------------------------------
+        # Step 7: Route to processor
+        # ----------------------------------------------------------
+        processor = self._select_processor(classification.file_type)
+        processing_path = self._file_type_to_path(classification.file_type)
+
+        logger.info(
+            "Routing %s to %s (type=%s, confidence=%.2f).",
+            filename,
+            processing_path,
+            classification.file_type.value,
+            classification.confidence,
+        )
+
+        # ----------------------------------------------------------
+        # Step 8: Process
+        # ----------------------------------------------------------
+        result = processor.process(
+            file_path=file_path,
+            profile=profile,
+            ingest_key=ingest_key,
+            ingest_run_id=ingest_run_id,
+            parse_result=parse_result,
+            classification_result=classification_result,
+            classification=classification,
+        )
+
+        # ----------------------------------------------------------
+        # Step 9: Merge parse errors and finalize
+        # ----------------------------------------------------------
+        self._merge_parse_errors(result, parse_errors)
+
+        elapsed = time.monotonic() - overall_start
+        # Override the processing_time to include full pipeline time
+        result = result.model_copy(
+            update={"processing_time_seconds": elapsed}
+        )
+
+        # PII-safe INFO log
+        logger.info(
+            "Processed %s: key=%s tier=%s type=%s confidence=%.2f "
+            "path=%s chunks=%d tables=%d time=%.3fs",
+            filename,
+            ingest_key[:16],
+            tier_used.value,
+            classification.file_type.value,
+            classification.confidence,
+            processing_path,
+            result.chunks_created,
+            result.tables_created,
+            elapsed,
+        )
+
+        return result
+
+    def process_batch(
+        self,
+        file_paths: list[str],
+    ) -> list[ProcessingResult]:
+        """Process multiple Excel files sequentially.
+
+        Parameters
+        ----------
+        file_paths:
+            List of filesystem paths to ``.xlsx`` files.
+
+        Returns
+        -------
+        list[ProcessingResult]
+            One result per input file, in the same order.
+        """
+        results: list[ProcessingResult] = []
+        for fp in file_paths:
+            results.append(self.process(fp))
+        return results
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_parse_stage_result(
+        profile: FileProfile,
+        parse_errors: list[IngestError],
+        parse_duration: float,
+    ) -> ParseStageResult:
+        """Build a ParseStageResult from a FileProfile and parse timing."""
+        # Determine primary parser from the first sheet that was parsed
+        primary_parser = ParserUsed.OPENPYXL
+        if profile.sheets:
+            primary_parser = profile.sheets[0].parser_used
+
+        # Compute skipped sheets info
+        skipped_reasons: dict[str, str] = {}
+        for error in parse_errors:
+            if error.code in (
+                ErrorCode.W_SHEET_SKIPPED_CHART,
+                ErrorCode.W_SHEET_SKIPPED_HIDDEN,
+                ErrorCode.W_SHEET_SKIPPED_PASSWORD,
+                ErrorCode.W_ROWS_TRUNCATED,
+            ) and error.sheet_name:
+                skipped_reasons[error.sheet_name] = error.code.value
+
+        # Determine fallback reason if the primary parser is not openpyxl
+        fallback_reason_code: str | None = None
+        if primary_parser == ParserUsed.PANDAS_FALLBACK:
+            fallback_reason_code = ErrorCode.E_PARSE_OPENPYXL_FAIL.value
+        elif primary_parser == ParserUsed.RAW_TEXT_FALLBACK:
+            fallback_reason_code = ErrorCode.E_PARSE_PANDAS_FAIL.value
+
+        sheets_parsed = len(profile.sheets)
+        sheets_skipped = len(skipped_reasons)
+
+        return ParseStageResult(
+            parser_used=primary_parser,
+            fallback_reason_code=fallback_reason_code,
+            sheets_parsed=sheets_parsed,
+            sheets_skipped=sheets_skipped,
+            skipped_reasons=skipped_reasons,
+            parse_duration_seconds=parse_duration,
+        )
+
+    @staticmethod
+    def _merge_parse_errors(
+        result: ProcessingResult,
+        parse_errors: list[IngestError],
+    ) -> None:
+        """Merge parse-stage errors/warnings into the ProcessingResult.
+
+        Errors (E_*) go into ``result.errors``; warnings (W_*) go into
+        ``result.warnings``.  All go into ``result.error_details``.
+        """
+        for error in parse_errors:
+            if error.code.value.startswith("E_"):
+                if error.code.value not in result.errors:
+                    result.errors.append(error.code.value)
+            else:
+                if error.code.value not in result.warnings:
+                    result.warnings.append(error.code.value)
+            result.error_details.append(error)
+
+    def _select_processor(
+        self, file_type: FileType
+    ) -> StructuredDBProcessor | TextSerializer | HybridSplitter:
+        """Select the appropriate processor based on file type."""
+        if file_type == FileType.TABULAR_DATA:
+            return self._structured_db_processor
+        elif file_type == FileType.FORMATTED_DOCUMENT:
+            return self._text_serializer
+        else:
+            return self._hybrid_splitter
+
+    @staticmethod
+    def _file_type_to_path(file_type: FileType) -> str:
+        """Map file type to the processing path name for logging."""
+        return {
+            FileType.TABULAR_DATA: "Path A (sql_agent)",
+            FileType.FORMATTED_DOCUMENT: "Path B (text_serialization)",
+            FileType.HYBRID: "Path C (hybrid_split)",
+        }.get(file_type, "unknown")
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def create_default_router(**overrides) -> ExcelRouter:
+    """Create an ExcelRouter with default SQLite + Ollama backends.
+
+    Convenience factory for local development and testing.  All defaults
+    can be overridden via keyword arguments:
+
+    - ``vector_store``: VectorStoreBackend (default: QdrantVectorStore)
+    - ``structured_db``: StructuredDBBackend (default: SQLiteStructuredDB)
+    - ``llm``: LLMBackend (default: OllamaLLM)
+    - ``embedder``: EmbeddingBackend (default: OllamaEmbedding)
+    - ``config``: ExcelProcessorConfig (default: ExcelProcessorConfig())
+
+    Any other keyword arguments are passed to ExcelProcessorConfig.
+
+    Returns
+    -------
+    ExcelRouter
+        A fully-configured router ready for ``process()`` calls.
+
+    Raises
+    ------
+    ImportError
+        If optional backend dependencies (e.g. ``httpx``, ``qdrant-client``)
+        are not installed.
+    """
+    from ingestkit_excel.backends import (
+        OllamaEmbedding,
+        OllamaLLM,
+        QdrantVectorStore,
+        SQLiteStructuredDB,
+    )
+
+    # Separate known router kwargs from config overrides
+    router_keys = {"vector_store", "structured_db", "llm", "embedder", "config"}
+    router_kwargs = {k: v for k, v in overrides.items() if k in router_keys}
+    config_kwargs = {k: v for k, v in overrides.items() if k not in router_keys}
+
+    config = router_kwargs.pop("config", None)
+    if config is None and config_kwargs:
+        config = ExcelProcessorConfig(**config_kwargs)
+    elif config is None:
+        config = ExcelProcessorConfig()
+
+    vector_store = router_kwargs.pop("vector_store", None)
+    if vector_store is None:
+        if QdrantVectorStore is None:
+            raise ImportError(
+                "qdrant-client is required for the default vector store. "
+                "Install with: pip install qdrant-client"
+            )
+        vector_store = QdrantVectorStore()
+
+    structured_db = router_kwargs.pop("structured_db", None)
+    if structured_db is None:
+        structured_db = SQLiteStructuredDB()
+
+    llm = router_kwargs.pop("llm", None)
+    if llm is None:
+        if OllamaLLM is None:
+            raise ImportError(
+                "httpx is required for the default LLM backend. "
+                "Install with: pip install httpx"
+            )
+        llm = OllamaLLM()
+
+    embedder = router_kwargs.pop("embedder", None)
+    if embedder is None:
+        if OllamaEmbedding is None:
+            raise ImportError(
+                "httpx is required for the default embedding backend. "
+                "Install with: pip install httpx"
+            )
+        embedder = OllamaEmbedding(model=config.embedding_model)
+
+    return ExcelRouter(
+        vector_store=vector_store,
+        structured_db=structured_db,
+        llm=llm,
+        embedder=embedder,
+        config=config,
+    )

--- a/packages/ingestkit-excel/tests/test_router.py
+++ b/packages/ingestkit-excel/tests/test_router.py
@@ -1,0 +1,1380 @@
+"""Tests for ingestkit_excel.router — ExcelRouter orchestrator and public API.
+
+All internal modules (ParserChain, ExcelInspector, LLMClassifier, processors)
+are mocked to test router logic in isolation.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ingestkit_excel.config import ExcelProcessorConfig
+from ingestkit_excel.errors import ErrorCode, IngestError
+from ingestkit_excel.models import (
+    ClassificationResult,
+    ClassificationStageResult,
+    ClassificationTier,
+    EmbedStageResult,
+    FileProfile,
+    FileType,
+    IngestKey,
+    IngestionMethod,
+    ParseStageResult,
+    ParserUsed,
+    ProcessingResult,
+    SheetProfile,
+    WrittenArtifacts,
+)
+from ingestkit_excel.router import ExcelRouter, create_default_router
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def config() -> ExcelProcessorConfig:
+    """Return a config with defaults for testing."""
+    return ExcelProcessorConfig(tenant_id="test_tenant")
+
+
+@pytest.fixture()
+def mock_vector_store():
+    """Return a mock VectorStoreBackend."""
+    vs = MagicMock()
+    vs.upsert_chunks.return_value = 1
+    vs.ensure_collection.return_value = None
+    return vs
+
+
+@pytest.fixture()
+def mock_structured_db():
+    """Return a mock StructuredDBBackend."""
+    db = MagicMock()
+    db.create_table_from_dataframe.return_value = None
+    db.get_connection_uri.return_value = "sqlite:///test.db"
+    return db
+
+
+@pytest.fixture()
+def mock_llm():
+    """Return a mock LLMBackend."""
+    llm = MagicMock()
+    llm.classify.return_value = {
+        "type": "tabular_data",
+        "confidence": 0.85,
+        "reasoning": "test reasoning",
+    }
+    return llm
+
+
+@pytest.fixture()
+def mock_embedder():
+    """Return a mock EmbeddingBackend."""
+    embedder = MagicMock()
+    embedder.embed.return_value = [[0.1] * 768]
+    embedder.dimension.return_value = 768
+    return embedder
+
+
+@pytest.fixture()
+def sample_sheet_profile() -> SheetProfile:
+    """Return a sample SheetProfile for tests."""
+    return SheetProfile(
+        name="Sheet1",
+        row_count=100,
+        col_count=5,
+        merged_cell_count=0,
+        merged_cell_ratio=0.0,
+        header_row_detected=True,
+        header_row_index=0,
+        header_values=["Name", "Age", "Salary", "Department", "ID"],
+        column_type_consistency=0.95,
+        numeric_ratio=0.4,
+        text_ratio=0.5,
+        empty_ratio=0.1,
+        sample_rows=[
+            ["Name", "Age", "Salary", "Department", "ID"],
+            ["Alice", "30", "50000", "Engineering", "1"],
+            ["Bob", "25", "45000", "Marketing", "2"],
+        ],
+        has_formulas=False,
+        is_hidden=False,
+        parser_used=ParserUsed.OPENPYXL,
+    )
+
+
+@pytest.fixture()
+def sample_file_profile(sample_sheet_profile: SheetProfile) -> FileProfile:
+    """Return a sample FileProfile with one tabular sheet."""
+    return FileProfile(
+        file_path="/tmp/test.xlsx",
+        file_size_bytes=1024,
+        sheet_count=1,
+        sheet_names=["Sheet1"],
+        sheets=[sample_sheet_profile],
+        has_password_protected_sheets=False,
+        has_chart_only_sheets=False,
+        total_merged_cells=0,
+        total_rows=100,
+        content_hash="abc123",
+    )
+
+
+@pytest.fixture()
+def tabular_classification() -> ClassificationResult:
+    """Return a high-confidence tabular classification."""
+    return ClassificationResult(
+        file_type=FileType.TABULAR_DATA,
+        confidence=0.9,
+        tier_used=ClassificationTier.RULE_BASED,
+        reasoning="All sheets classified as tabular_data.",
+        signals={"per_sheet": {}},
+    )
+
+
+@pytest.fixture()
+def formatted_classification() -> ClassificationResult:
+    """Return a high-confidence formatted document classification."""
+    return ClassificationResult(
+        file_type=FileType.FORMATTED_DOCUMENT,
+        confidence=0.9,
+        tier_used=ClassificationTier.RULE_BASED,
+        reasoning="All sheets classified as formatted_document.",
+        signals={"per_sheet": {}},
+    )
+
+
+@pytest.fixture()
+def hybrid_classification() -> ClassificationResult:
+    """Return a high-confidence hybrid classification."""
+    return ClassificationResult(
+        file_type=FileType.HYBRID,
+        confidence=0.9,
+        tier_used=ClassificationTier.RULE_BASED,
+        reasoning="Sheets disagree: hybrid classification.",
+        signals={"per_sheet": {}},
+    )
+
+
+@pytest.fixture()
+def inconclusive_classification() -> ClassificationResult:
+    """Return an inconclusive classification (confidence 0.0)."""
+    return ClassificationResult(
+        file_type=FileType.HYBRID,
+        confidence=0.0,
+        tier_used=ClassificationTier.RULE_BASED,
+        reasoning="Inconclusive: could not classify.",
+        signals={"per_sheet": {}},
+    )
+
+
+@pytest.fixture()
+def sample_processing_result() -> ProcessingResult:
+    """Return a sample ProcessingResult for processor mock return values."""
+    return ProcessingResult(
+        file_path="/tmp/test.xlsx",
+        ingest_key="abc123",
+        ingest_run_id="run-123",
+        tenant_id="test_tenant",
+        parse_result=ParseStageResult(
+            parser_used=ParserUsed.OPENPYXL,
+            fallback_reason_code=None,
+            sheets_parsed=1,
+            sheets_skipped=0,
+            skipped_reasons={},
+            parse_duration_seconds=0.1,
+        ),
+        classification_result=ClassificationStageResult(
+            tier_used=ClassificationTier.RULE_BASED,
+            file_type=FileType.TABULAR_DATA,
+            confidence=0.9,
+            signals=None,
+            reasoning="Classified as tabular.",
+            per_sheet_types=None,
+            classification_duration_seconds=0.05,
+        ),
+        embed_result=EmbedStageResult(
+            texts_embedded=1,
+            embedding_dimension=768,
+            embed_duration_seconds=0.02,
+        ),
+        classification=ClassificationResult(
+            file_type=FileType.TABULAR_DATA,
+            confidence=0.9,
+            tier_used=ClassificationTier.RULE_BASED,
+            reasoning="Tabular data.",
+        ),
+        ingestion_method=IngestionMethod.SQL_AGENT,
+        chunks_created=2,
+        tables_created=1,
+        tables=["sheet1"],
+        written=WrittenArtifacts(
+            vector_point_ids=["id1", "id2"],
+            vector_collection="helpdesk",
+            db_table_names=["sheet1"],
+        ),
+        errors=[],
+        warnings=[],
+        error_details=[],
+        processing_time_seconds=0.5,
+    )
+
+
+def _make_ingest_key():
+    """Build a deterministic IngestKey for patching."""
+    return IngestKey(
+        content_hash="abc123",
+        source_uri="file:///tmp/test.xlsx",
+        parser_version="ingestkit_excel:1.0.0",
+        tenant_id="test_tenant",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: Constructor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExcelRouterInit:
+    """Test ExcelRouter construction."""
+
+    def test_creates_with_all_backends(
+        self, mock_vector_store, mock_structured_db, mock_llm, mock_embedder, config
+    ):
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+        assert router._config is config
+        assert router._parser_chain is not None
+        assert router._inspector is not None
+        assert router._llm_classifier is not None
+        assert router._structured_db_processor is not None
+        assert router._text_serializer is not None
+        assert router._hybrid_splitter is not None
+
+    def test_creates_with_default_config(
+        self, mock_vector_store, mock_structured_db, mock_llm, mock_embedder
+    ):
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+        )
+        assert router._config is not None
+        assert isinstance(router._config, ExcelProcessorConfig)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Happy path — Path A (tabular)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRouterPathA:
+    """Test routing to Path A (StructuredDBProcessor) for tabular files."""
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    @patch.object(ExcelRouter, "_select_processor")
+    def test_tabular_routes_to_path_a(
+        self,
+        mock_select,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        tabular_classification,
+        sample_processing_result,
+    ):
+        """A file classified as TABULAR_DATA should be routed to StructuredDBProcessor."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        # Mock processor
+        mock_processor = MagicMock()
+        mock_processor.process.return_value = sample_processing_result
+        mock_select.return_value = mock_processor
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_classify:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_classify.return_value = tabular_classification
+
+            result = router.process("/tmp/test.xlsx")
+
+        assert result.chunks_created == 2
+        assert result.tables_created == 1
+        mock_processor.process.assert_called_once()
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_tabular_full_flow(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        tabular_classification,
+        sample_processing_result,
+    ):
+        """End-to-end test of full tabular flow with mocked internals."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_classify, \
+             patch.object(router._structured_db_processor, "process") as mock_proc:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_classify.return_value = tabular_classification
+            mock_proc.return_value = sample_processing_result
+
+            result = router.process("/tmp/test.xlsx")
+
+        assert isinstance(result, ProcessingResult)
+        assert result.ingest_key == "abc123"  # from sample_processing_result
+        assert result.tenant_id == "test_tenant"
+        mock_proc.assert_called_once()
+
+        # Verify processor was called with correct args
+        call_kwargs = mock_proc.call_args
+        assert call_kwargs[1]["file_path"] == "/tmp/test.xlsx"
+        assert call_kwargs[1]["ingest_key"] == _make_ingest_key().key
+        assert call_kwargs[1]["profile"] is sample_file_profile
+
+
+# ---------------------------------------------------------------------------
+# Tests: Happy path — Path B (formatted document)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRouterPathB:
+    """Test routing to Path B (TextSerializer) for formatted documents."""
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_formatted_routes_to_path_b(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        formatted_classification,
+        sample_processing_result,
+    ):
+        """A file classified as FORMATTED_DOCUMENT routes to TextSerializer."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        # Adjust the processing result for path B
+        path_b_result = sample_processing_result.model_copy(
+            update={
+                "ingestion_method": IngestionMethod.TEXT_SERIALIZATION,
+                "tables_created": 0,
+                "tables": [],
+            }
+        )
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_classify, \
+             patch.object(router._text_serializer, "process") as mock_proc:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_classify.return_value = formatted_classification
+            mock_proc.return_value = path_b_result
+
+            result = router.process("/tmp/test.xlsx")
+
+        assert isinstance(result, ProcessingResult)
+        mock_proc.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Happy path — Path C (hybrid)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRouterPathC:
+    """Test routing to Path C (HybridSplitter) for hybrid files."""
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_hybrid_routes_to_path_c(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        hybrid_classification,
+        sample_processing_result,
+    ):
+        """A file classified as HYBRID routes to HybridSplitter."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        path_c_result = sample_processing_result.model_copy(
+            update={
+                "ingestion_method": IngestionMethod.HYBRID_SPLIT,
+            }
+        )
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_classify, \
+             patch.object(router._hybrid_splitter, "process") as mock_proc:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_classify.return_value = hybrid_classification
+            mock_proc.return_value = path_c_result
+
+            result = router.process("/tmp/test.xlsx")
+
+        assert isinstance(result, ProcessingResult)
+        mock_proc.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tier escalation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTierEscalation:
+    """Test classification tier escalation logic."""
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_tier1_inconclusive_escalates_to_tier2(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        inconclusive_classification,
+        tabular_classification,
+        sample_processing_result,
+    ):
+        """When Tier 1 returns confidence 0.0, should escalate to Tier 2."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        # Tier 2 returns a confident result
+        tier2_result = ClassificationResult(
+            file_type=FileType.TABULAR_DATA,
+            confidence=0.85,
+            tier_used=ClassificationTier.LLM_BASIC,
+            reasoning="LLM classified as tabular.",
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_tier1, \
+             patch.object(router._llm_classifier, "classify") as mock_tier2, \
+             patch.object(router._structured_db_processor, "process") as mock_proc:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_tier1.return_value = inconclusive_classification
+            mock_tier2.return_value = tier2_result
+            mock_proc.return_value = sample_processing_result
+
+            result = router.process("/tmp/test.xlsx")
+
+        # Tier 2 was called with LLM_BASIC
+        mock_tier2.assert_called_once_with(
+            sample_file_profile, ClassificationTier.LLM_BASIC
+        )
+        mock_proc.assert_called_once()
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_tier2_low_confidence_escalates_to_tier3(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        inconclusive_classification,
+        sample_processing_result,
+    ):
+        """When Tier 2 confidence < threshold, should escalate to Tier 3."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        # Tier 2 returns low confidence
+        tier2_result = ClassificationResult(
+            file_type=FileType.FORMATTED_DOCUMENT,
+            confidence=0.4,  # below default threshold of 0.6
+            tier_used=ClassificationTier.LLM_BASIC,
+            reasoning="Uncertain classification.",
+        )
+
+        # Tier 3 returns confident result
+        tier3_result = ClassificationResult(
+            file_type=FileType.FORMATTED_DOCUMENT,
+            confidence=0.8,
+            tier_used=ClassificationTier.LLM_REASONING,
+            reasoning="Reasoning model classified as formatted.",
+        )
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        path_b_result = sample_processing_result.model_copy(
+            update={
+                "ingestion_method": IngestionMethod.TEXT_SERIALIZATION,
+                "tables_created": 0,
+                "tables": [],
+            }
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_tier1, \
+             patch.object(router._llm_classifier, "classify") as mock_llm_classify, \
+             patch.object(router._text_serializer, "process") as mock_proc:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_tier1.return_value = inconclusive_classification
+            mock_llm_classify.side_effect = [tier2_result, tier3_result]
+            mock_proc.return_value = path_b_result
+
+            result = router.process("/tmp/test.xlsx")
+
+        # LLM classifier called twice (Tier 2, then Tier 3)
+        assert mock_llm_classify.call_count == 2
+        mock_llm_classify.assert_any_call(
+            sample_file_profile, ClassificationTier.LLM_BASIC
+        )
+        mock_llm_classify.assert_any_call(
+            sample_file_profile, ClassificationTier.LLM_REASONING
+        )
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_tier3_disabled_stops_at_tier2(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        sample_file_profile,
+        inconclusive_classification,
+        sample_processing_result,
+    ):
+        """When enable_tier3=False, should not escalate beyond Tier 2."""
+        config = ExcelProcessorConfig(
+            tenant_id="test_tenant", enable_tier3=False
+        )
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        tier2_result = ClassificationResult(
+            file_type=FileType.TABULAR_DATA,
+            confidence=0.4,  # below threshold but Tier 3 disabled
+            tier_used=ClassificationTier.LLM_BASIC,
+            reasoning="Low confidence classification.",
+        )
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_tier1, \
+             patch.object(router._llm_classifier, "classify") as mock_llm_classify, \
+             patch.object(router._structured_db_processor, "process") as mock_proc:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_tier1.return_value = inconclusive_classification
+            mock_llm_classify.return_value = tier2_result
+            mock_proc.return_value = sample_processing_result
+
+            result = router.process("/tmp/test.xlsx")
+
+        # LLM classifier called only once (Tier 2)
+        mock_llm_classify.assert_called_once_with(
+            sample_file_profile, ClassificationTier.LLM_BASIC
+        )
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_tier1_confident_skips_llm(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        tabular_classification,
+        sample_processing_result,
+    ):
+        """When Tier 1 is confident (>0.0), should NOT call LLM classifier."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_tier1, \
+             patch.object(router._llm_classifier, "classify") as mock_llm_classify, \
+             patch.object(router._structured_db_processor, "process") as mock_proc:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_tier1.return_value = tabular_classification
+            mock_proc.return_value = sample_processing_result
+
+            result = router.process("/tmp/test.xlsx")
+
+        mock_llm_classify.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Fail-closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFailClosed:
+    """Test fail-closed behavior when classification is inconclusive."""
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_all_tiers_fail_returns_inconclusive(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        inconclusive_classification,
+    ):
+        """When all tiers return confidence 0.0, should return fail-closed result."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        # All tiers fail
+        tier2_fail = ClassificationResult(
+            file_type=FileType.TABULAR_DATA,
+            confidence=0.0,
+            tier_used=ClassificationTier.LLM_BASIC,
+            reasoning="LLM failed.",
+        )
+        tier3_fail = ClassificationResult(
+            file_type=FileType.TABULAR_DATA,
+            confidence=0.0,
+            tier_used=ClassificationTier.LLM_REASONING,
+            reasoning="Reasoning model failed.",
+        )
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_tier1, \
+             patch.object(router._llm_classifier, "classify") as mock_llm_classify:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_tier1.return_value = inconclusive_classification
+            mock_llm_classify.side_effect = [tier2_fail, tier3_fail]
+
+            result = router.process("/tmp/test.xlsx")
+
+        assert result.chunks_created == 0
+        assert result.tables_created == 0
+        assert result.tables == []
+        assert ErrorCode.E_CLASSIFY_INCONCLUSIVE.value in result.errors
+        assert any(
+            e.code == ErrorCode.E_CLASSIFY_INCONCLUSIVE
+            for e in result.error_details
+        )
+        assert result.ingest_key == _make_ingest_key().key
+        assert result.ingest_run_id  # should have a UUID
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_fail_closed_has_correct_structure(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        inconclusive_classification,
+    ):
+        """Fail-closed result should have all required fields populated."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        tier2_fail = ClassificationResult(
+            file_type=FileType.TABULAR_DATA,
+            confidence=0.0,
+            tier_used=ClassificationTier.LLM_BASIC,
+            reasoning="Failed.",
+        )
+        tier3_fail = ClassificationResult(
+            file_type=FileType.TABULAR_DATA,
+            confidence=0.0,
+            tier_used=ClassificationTier.LLM_REASONING,
+            reasoning="Also failed.",
+        )
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_tier1, \
+             patch.object(router._llm_classifier, "classify") as mock_llm_classify:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_tier1.return_value = inconclusive_classification
+            mock_llm_classify.side_effect = [tier2_fail, tier3_fail]
+
+            result = router.process("/tmp/test.xlsx")
+
+        # Verify all required fields present
+        assert result.file_path == "/tmp/test.xlsx"
+        assert result.ingest_key is not None
+        assert result.ingest_run_id is not None
+        assert result.tenant_id == "test_tenant"
+        assert result.parse_result is not None
+        assert result.classification_result is not None
+        assert result.classification is not None
+        assert result.processing_time_seconds > 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: Parse error merging
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestParseErrorMerging:
+    """Test that parse-stage errors are merged into the final result."""
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_parse_warnings_merged_into_result(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        tabular_classification,
+        sample_processing_result,
+    ):
+        """Parse fallback warnings should appear in result.warnings."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        parse_errors = [
+            IngestError(
+                code=ErrorCode.W_PARSER_FALLBACK,
+                message="Sheet 'Sheet1' parsed via pandas fallback.",
+                sheet_name="Sheet1",
+                stage="parse",
+                recoverable=True,
+            ),
+        ]
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_classify, \
+             patch.object(router._structured_db_processor, "process") as mock_proc:
+            mock_parse.return_value = (sample_file_profile, parse_errors)
+            mock_classify.return_value = tabular_classification
+            mock_proc.return_value = sample_processing_result
+
+            result = router.process("/tmp/test.xlsx")
+
+        assert ErrorCode.W_PARSER_FALLBACK.value in result.warnings
+        assert any(
+            e.code == ErrorCode.W_PARSER_FALLBACK
+            for e in result.error_details
+        )
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_parse_errors_merged_into_result(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        tabular_classification,
+        sample_processing_result,
+    ):
+        """Parse errors (E_*) should appear in result.errors."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        parse_errors = [
+            IngestError(
+                code=ErrorCode.E_PARSE_CORRUPT,
+                message="All parsers failed for sheet 'Sheet2'.",
+                sheet_name="Sheet2",
+                stage="parse",
+                recoverable=False,
+            ),
+        ]
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_classify, \
+             patch.object(router._structured_db_processor, "process") as mock_proc:
+            mock_parse.return_value = (sample_file_profile, parse_errors)
+            mock_classify.return_value = tabular_classification
+            mock_proc.return_value = sample_processing_result
+
+            result = router.process("/tmp/test.xlsx")
+
+        assert ErrorCode.E_PARSE_CORRUPT.value in result.errors
+
+
+# ---------------------------------------------------------------------------
+# Tests: ParseStageResult building
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuildParseStageResult:
+    """Test _build_parse_stage_result helper."""
+
+    def test_openpyxl_primary_parser(self, sample_file_profile):
+        """When sheets use openpyxl, ParseStageResult should reflect that."""
+        result = ExcelRouter._build_parse_stage_result(
+            sample_file_profile, [], 0.1
+        )
+        assert result.parser_used == ParserUsed.OPENPYXL
+        assert result.fallback_reason_code is None
+        assert result.sheets_parsed == 1
+        assert result.sheets_skipped == 0
+        assert result.parse_duration_seconds == 0.1
+
+    def test_pandas_fallback_parser(self, sample_file_profile):
+        """When first sheet used pandas fallback, record the fallback reason."""
+        profile = sample_file_profile.model_copy(deep=True)
+        profile.sheets[0] = profile.sheets[0].model_copy(
+            update={"parser_used": ParserUsed.PANDAS_FALLBACK}
+        )
+        result = ExcelRouter._build_parse_stage_result(profile, [], 0.2)
+        assert result.parser_used == ParserUsed.PANDAS_FALLBACK
+        assert result.fallback_reason_code == ErrorCode.E_PARSE_OPENPYXL_FAIL.value
+
+    def test_raw_text_fallback_parser(self, sample_file_profile):
+        """When first sheet used raw_text fallback, record the fallback reason."""
+        profile = sample_file_profile.model_copy(deep=True)
+        profile.sheets[0] = profile.sheets[0].model_copy(
+            update={"parser_used": ParserUsed.RAW_TEXT_FALLBACK}
+        )
+        result = ExcelRouter._build_parse_stage_result(profile, [], 0.3)
+        assert result.parser_used == ParserUsed.RAW_TEXT_FALLBACK
+        assert result.fallback_reason_code == ErrorCode.E_PARSE_PANDAS_FAIL.value
+
+    def test_skipped_sheets_tracked(self, sample_file_profile):
+        """Skipped sheets should be counted and reasons recorded."""
+        errors = [
+            IngestError(
+                code=ErrorCode.W_SHEET_SKIPPED_CHART,
+                message="Chart sheet skipped.",
+                sheet_name="Charts",
+                stage="parse",
+                recoverable=True,
+            ),
+            IngestError(
+                code=ErrorCode.W_SHEET_SKIPPED_HIDDEN,
+                message="Hidden sheet skipped.",
+                sheet_name="Hidden",
+                stage="parse",
+                recoverable=True,
+            ),
+        ]
+        result = ExcelRouter._build_parse_stage_result(
+            sample_file_profile, errors, 0.1
+        )
+        assert result.sheets_skipped == 2
+        assert "Charts" in result.skipped_reasons
+        assert "Hidden" in result.skipped_reasons
+        assert result.skipped_reasons["Charts"] == ErrorCode.W_SHEET_SKIPPED_CHART.value
+
+    def test_empty_profile_defaults(self):
+        """An empty profile (no sheets) should default to openpyxl parser."""
+        profile = FileProfile(
+            file_path="/tmp/empty.xlsx",
+            file_size_bytes=0,
+            sheet_count=0,
+            sheet_names=[],
+            sheets=[],
+            has_password_protected_sheets=False,
+            has_chart_only_sheets=False,
+            total_merged_cells=0,
+            total_rows=0,
+            content_hash="empty",
+        )
+        result = ExcelRouter._build_parse_stage_result(profile, [], 0.01)
+        assert result.parser_used == ParserUsed.OPENPYXL
+        assert result.sheets_parsed == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: Batch processing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProcessBatch:
+    """Test process_batch."""
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_batch_processes_all_files(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        tabular_classification,
+        sample_processing_result,
+    ):
+        """process_batch should return one result per input file."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_classify, \
+             patch.object(router._structured_db_processor, "process") as mock_proc:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_classify.return_value = tabular_classification
+            mock_proc.return_value = sample_processing_result
+
+            results = router.process_batch(["/tmp/a.xlsx", "/tmp/b.xlsx", "/tmp/c.xlsx"])
+
+        assert len(results) == 3
+        assert mock_proc.call_count == 3
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_batch_empty_list(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+    ):
+        """process_batch with empty list should return empty list."""
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+        results = router.process_batch([])
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: PII-safe logging
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPIISafeLogging:
+    """Test that logging is PII-safe."""
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_info_log_after_processing(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        tabular_classification,
+        sample_processing_result,
+        caplog,
+    ):
+        """INFO log after processing should include truncated key, not raw data."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_classify, \
+             patch.object(router._structured_db_processor, "process") as mock_proc:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_classify.return_value = tabular_classification
+            mock_proc.return_value = sample_processing_result
+
+            import logging
+            with caplog.at_level(logging.INFO, logger="ingestkit_excel"):
+                result = router.process("/tmp/test.xlsx")
+
+        # Should have an info log with "Processed"
+        info_messages = [r.message for r in caplog.records if r.levelname == "INFO"]
+        processed_msgs = [m for m in info_messages if "Processed" in m]
+        assert len(processed_msgs) >= 1
+
+        # The key should be truncated to 16 chars
+        key_16 = _make_ingest_key().key[:16]
+        assert any(key_16 in m for m in processed_msgs)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Processor selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProcessorSelection:
+    """Test _select_processor picks the right processor."""
+
+    def test_tabular_selects_structured_db(
+        self, mock_vector_store, mock_structured_db, mock_llm, mock_embedder, config
+    ):
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+        processor = router._select_processor(FileType.TABULAR_DATA)
+        assert processor is router._structured_db_processor
+
+    def test_formatted_selects_text_serializer(
+        self, mock_vector_store, mock_structured_db, mock_llm, mock_embedder, config
+    ):
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+        processor = router._select_processor(FileType.FORMATTED_DOCUMENT)
+        assert processor is router._text_serializer
+
+    def test_hybrid_selects_hybrid_splitter(
+        self, mock_vector_store, mock_structured_db, mock_llm, mock_embedder, config
+    ):
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+        processor = router._select_processor(FileType.HYBRID)
+        assert processor is router._hybrid_splitter
+
+
+# ---------------------------------------------------------------------------
+# Tests: source_uri passthrough
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSourceUri:
+    """Test that source_uri is passed through to compute_ingest_key."""
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_source_uri_passed(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        tabular_classification,
+        sample_processing_result,
+    ):
+        """When source_uri is provided, it should be passed to compute_ingest_key."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_classify, \
+             patch.object(router._structured_db_processor, "process") as mock_proc:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_classify.return_value = tabular_classification
+            mock_proc.return_value = sample_processing_result
+
+            result = router.process("/tmp/test.xlsx", source_uri="s3://bucket/test.xlsx")
+
+        mock_ingest_key.assert_called_once_with(
+            file_path="/tmp/test.xlsx",
+            parser_version=config.parser_version,
+            tenant_id=config.tenant_id,
+            source_uri="s3://bucket/test.xlsx",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_default_router factory
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCreateDefaultRouter:
+    """Test the create_default_router factory function."""
+
+    def test_factory_with_all_overrides(
+        self, mock_vector_store, mock_structured_db, mock_llm, mock_embedder, config
+    ):
+        """When all backends are overridden, should use them directly."""
+        router = create_default_router(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+        assert isinstance(router, ExcelRouter)
+        assert router._config is config
+
+    def test_factory_with_config_kwargs(
+        self, mock_vector_store, mock_structured_db, mock_llm, mock_embedder
+    ):
+        """Config kwargs passed as flat arguments should build ExcelProcessorConfig."""
+        router = create_default_router(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            tenant_id="from_kwargs",
+        )
+        assert router._config.tenant_id == "from_kwargs"
+
+
+# ---------------------------------------------------------------------------
+# Tests: file_type_to_path mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFileTypeToPath:
+    """Test the _file_type_to_path helper."""
+
+    def test_tabular(self):
+        assert ExcelRouter._file_type_to_path(FileType.TABULAR_DATA) == "Path A (sql_agent)"
+
+    def test_formatted(self):
+        assert ExcelRouter._file_type_to_path(FileType.FORMATTED_DOCUMENT) == "Path B (text_serialization)"
+
+    def test_hybrid(self):
+        assert ExcelRouter._file_type_to_path(FileType.HYBRID) == "Path C (hybrid_split)"
+
+
+# ---------------------------------------------------------------------------
+# Tests: IngestKey and ingest_run_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestIngestKeyAndRunId:
+    """Test that ingest_key and ingest_run_id are correctly propagated."""
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_ingest_key_uses_key_property(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        tabular_classification,
+        sample_processing_result,
+    ):
+        """The hex string from IngestKey.key should be used, not the object."""
+        ik = _make_ingest_key()
+        mock_ingest_key.return_value = ik
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_classify, \
+             patch.object(router._structured_db_processor, "process") as mock_proc:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_classify.return_value = tabular_classification
+            mock_proc.return_value = sample_processing_result
+
+            result = router.process("/tmp/test.xlsx")
+
+        # Verify processor received the .key hex string
+        call_kwargs = mock_proc.call_args[1]
+        assert call_kwargs["ingest_key"] == ik.key
+        # ingest_run_id should be a UUID string
+        assert len(call_kwargs["ingest_run_id"]) == 36  # UUID4 format
+
+
+# ---------------------------------------------------------------------------
+# Tests: Classification result propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestClassificationResultPropagation:
+    """Test that classification stage results are properly built and passed."""
+
+    @patch("ingestkit_excel.router.compute_ingest_key")
+    def test_classification_stage_result_built_correctly(
+        self,
+        mock_ingest_key,
+        mock_vector_store,
+        mock_structured_db,
+        mock_llm,
+        mock_embedder,
+        config,
+        sample_file_profile,
+        tabular_classification,
+        sample_processing_result,
+    ):
+        """ClassificationStageResult should capture tier, type, confidence."""
+        mock_ingest_key.return_value = _make_ingest_key()
+
+        router = ExcelRouter(
+            vector_store=mock_vector_store,
+            structured_db=mock_structured_db,
+            llm=mock_llm,
+            embedder=mock_embedder,
+            config=config,
+        )
+
+        with patch.object(router._parser_chain, "parse") as mock_parse, \
+             patch.object(router._inspector, "classify") as mock_classify, \
+             patch.object(router._structured_db_processor, "process") as mock_proc:
+            mock_parse.return_value = (sample_file_profile, [])
+            mock_classify.return_value = tabular_classification
+            mock_proc.return_value = sample_processing_result
+
+            result = router.process("/tmp/test.xlsx")
+
+        call_kwargs = mock_proc.call_args[1]
+        cr = call_kwargs["classification_result"]
+        assert isinstance(cr, ClassificationStageResult)
+        assert cr.tier_used == ClassificationTier.RULE_BASED
+        assert cr.file_type == FileType.TABULAR_DATA
+        assert cr.confidence == 0.9
+        assert cr.classification_duration_seconds > 0


### PR DESCRIPTION
## What
Top-level `ExcelRouter` orchestrator that wires together all pipeline stages: parse → classify → route → process.

## Why
Closes #12 — Provides the single entry point for Excel file ingestion with automatic classification and routing.

## How
- **12-step process flow**: compute ingest key, parse, 3-tier classification, route to Path A/B/C, assemble result
- **Tier escalation**: Tier 1 (rule-based) → Tier 2 (LLM basic) → Tier 3 (LLM reasoning) with configurable thresholds
- **Fail-closed**: Returns `E_CLASSIFY_INCONCLUSIVE` with zero output when all tiers fail
- **PII-safe logging**: Logger `"ingestkit_excel"`, truncated keys, no raw cell data
- **Batch**: `process_batch()` for multiple files
- **Factory**: `create_default_router(**overrides)` convenience function

## Stack
- [x] Backend

## Verification
- [x] `pytest tests/test_router.py -v` passes (33 tests)
- [x] `pytest tests/ -v` passes (546 tests, zero regressions)
- [x] Manual tests: round-trip, tier escalation, fail-closed, batch — all pass

## Risks / Rollback
Low risk — new module, minimal changes to existing __init__.py exports.

---
Artifacts: `.agents/outputs/*-12-*.md`