### PR TITLE
fix(ingestkit-pdf): Fix TableFinder len() in router + expand integration test

### DIFF
--- a/packages/ingestkit-pdf/src/ingestkit_pdf/router.py
+++ b/packages/ingestkit-pdf/src/ingestkit_pdf/router.py
@@ -593,13 +593,15 @@ class PDFRouter:
         font_count = len(font_names)
 
         # Tables
-        tables: Any = []
+        table_count = 0
         if hasattr(page, "find_tables"):
             try:
-                tables = page.find_tables()
+                finder = page.find_tables()
+                # PyMuPDF returns a TableFinder; access .tables for the list
+                tbl_list = getattr(finder, "tables", finder)
+                table_count = len(tbl_list) if tbl_list else 0
             except Exception:
-                tables = []
-        table_count = len(tables) if tables else 0
+                table_count = 0
 
         # Form fields
         has_form_fields = False


### PR DESCRIPTION
## Summary
- Fix `PDFRouter._build_page_profile()` where `page.find_tables()` returns a `TableFinder` object (not a list) in newer PyMuPDF — access `.tables` attribute first
- Expand `test_real_pdf_integration.py` with 3 new Phase 4 modules: PDFRouter E2E, ComplexProcessor, PaddleOCR
- All 13 modules pass against `Product_Catalog_2025.pdf`

## Test plan
- [x] `python test_real_pdf_integration.py` — 13/13 pass
- [x] PDFRouter processes full pipeline (security→profile→classify→route)
- [x] ComplexProcessor produces 16 chunks with mock backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)