### PR TITLE
feat(ingestkit-forms): Template lifecycle, approved-only filtering, redaction flags

### DIFF
--- a/packages/ingestkit-forms/src/ingestkit_forms/__init__.py
+++ b/packages/ingestkit-forms/src/ingestkit_forms/__init__.py
@@ -59,6 +59,7 @@ from ingestkit_forms.models import (
     RollbackResult,
     SourceFormat,
     TemplateMatch,
+    TemplateStatus,
 )
 
 __all__: list[str] = [
@@ -72,6 +73,7 @@ __all__: list[str] = [
     "SourceFormat",
     "FieldType",
     "DualWriteMode",
+    "TemplateStatus",
     # Template models
     "BoundingBox",
     "CellAddress",

--- a/packages/ingestkit-forms/src/ingestkit_forms/output/dual_writer.py
+++ b/packages/ingestkit-forms/src/ingestkit_forms/output/dual_writer.py
@@ -72,7 +72,12 @@ def redact_extraction(
 
     for field in redacted.fields:
         if isinstance(field.value, str):
-            field.value = apply_redaction(field.value, compiled)
+            new_value = apply_redaction(field.value, compiled)
+            if new_value != field.value:
+                field.value = new_value
+                field.redacted = True
+                if field.raw_value is not None:
+                    field.raw_value = "[REDACTED]"
 
     return redacted
 

--- a/packages/ingestkit-forms/src/ingestkit_forms/protocols.py
+++ b/packages/ingestkit-forms/src/ingestkit_forms/protocols.py
@@ -154,8 +154,12 @@ class FormTemplateStore(Protocol):
         tenant_id: str | None = None,
         source_format: str | None = None,
         active_only: bool = True,
+        status: str | None = None,
     ) -> list[FormTemplate]:
-        """List templates matching the filters."""
+        """List templates matching the filters.
+
+        If status is provided, only templates with that status are returned.
+        """
         ...
 
     def list_versions(self, template_id: str) -> list[FormTemplate]:

--- a/packages/ingestkit-forms/src/ingestkit_forms/stores/filesystem.py
+++ b/packages/ingestkit-forms/src/ingestkit_forms/stores/filesystem.py
@@ -120,11 +120,13 @@ class FileSystemTemplateStore:
         tenant_id: str | None = None,
         source_format: str | None = None,
         active_only: bool = True,
+        status: str | None = None,
     ) -> list[FormTemplate]:
         """List templates matching the filters.
 
         Returns the latest version of each template.
         If active_only=True (default), excludes soft-deleted templates.
+        If status is provided, only templates with that status are returned.
         """
         results: list[FormTemplate] = []
 
@@ -151,6 +153,9 @@ class FileSystemTemplateStore:
                 continue
 
             if source_format is not None and template.source_format.value != source_format:
+                continue
+
+            if status is not None and template.status.value != status:
                 continue
 
             results.append(template)
@@ -221,15 +226,16 @@ class FileSystemTemplateStore:
         tenant_id: str | None = None,
         source_format: str | None = None,
     ) -> list[tuple[str, str, int, bytes]]:
-        """Return (template_id, name, version, fingerprint) for all active templates.
+        """Return (template_id, name, version, fingerprint) for approved templates.
 
         Used by the matcher for efficient batch comparison.
-        Only returns templates with non-None layout_fingerprint.
+        Only returns approved templates with non-None layout_fingerprint.
         """
         templates = self.list_templates(
             tenant_id=tenant_id,
             source_format=source_format,
             active_only=True,
+            status="approved",
         )
         results: list[tuple[str, str, int, bytes]] = []
         for t in templates:

--- a/packages/ingestkit-forms/tests/conftest.py
+++ b/packages/ingestkit-forms/tests/conftest.py
@@ -194,6 +194,7 @@ class MockFormTemplateStore:
         tenant_id: str | None = None,
         source_format: str | None = None,
         active_only: bool = True,
+        status: str | None = None,
     ) -> list[FormTemplate]:
         results: list[FormTemplate] = []
         for tid in self._templates:
@@ -205,6 +206,8 @@ class MockFormTemplateStore:
             if tenant_id is not None and template.tenant_id != tenant_id:
                 continue
             if source_format is not None and template.source_format.value != source_format:
+                continue
+            if status is not None and template.status.value != status:
                 continue
             results.append(template)
         return results
@@ -248,6 +251,7 @@ class MockFormTemplateStore:
             tenant_id=tenant_id,
             source_format=source_format,
             active_only=True,
+            status="approved",
         )
         results: list[tuple[str, str, int, bytes]] = []
         for t in templates:
@@ -566,6 +570,7 @@ def make_template(
     template_id: str | None = None,
     tenant_id: str | None = None,
     version: int = 1,
+    status: str | None = None,
 ) -> FormTemplate:
     """Factory for FormTemplate test instances."""
     if fields is None:
@@ -582,6 +587,8 @@ def make_template(
         kwargs["template_id"] = template_id
     if tenant_id is not None:
         kwargs["tenant_id"] = tenant_id
+    if status is not None:
+        kwargs["status"] = status
     return FormTemplate(**kwargs)
 
 

--- a/packages/ingestkit-forms/tests/test_matcher.py
+++ b/packages/ingestkit-forms/tests/test_matcher.py
@@ -429,6 +429,7 @@ class TestFormMatcherMatchDocument:
             source_format=SourceFormat.PDF,
             layout_fingerprint=fp_concat,
             template_id="tmpl-1",
+            status="approved",
         )
         mock_template_store.save_template(tmpl)
 
@@ -479,6 +480,7 @@ class TestFormMatcherMatchDocument:
             source_format=SourceFormat.PDF,
             layout_fingerprint=exact_fp,
             template_id="tmpl-exact",
+            status="approved",
         )
 
         # Off-by-one template (similarity = 0.5 per cell) won't pass
@@ -495,6 +497,7 @@ class TestFormMatcherMatchDocument:
             source_format=SourceFormat.PDF,
             layout_fingerprint=mixed_fp,
             template_id="tmpl-mixed",
+            status="approved",
         )
 
         mock_template_store.save_template(tmpl_exact)
@@ -522,6 +525,7 @@ class TestFormMatcherMatchDocument:
             source_format=SourceFormat.PDF,
             layout_fingerprint=fp_concat,
             template_id="tmpl-fp-fail",
+            status="approved",
         )
         mock_template_store.save_template(tmpl)
 
@@ -545,6 +549,7 @@ class TestFormMatcherMatchDocument:
             source_format=SourceFormat.PDF,
             layout_fingerprint=good_fp,
             template_id="tmpl-good",
+            status="approved",
         )
 
         # Bad fingerprint: wrong length
@@ -553,6 +558,7 @@ class TestFormMatcherMatchDocument:
             source_format=SourceFormat.PDF,
             layout_fingerprint=bytes([0] * 100),  # not 320
             template_id="tmpl-bad",
+            status="approved",
         )
 
         mock_template_store.save_template(tmpl_good)

--- a/packages/ingestkit-forms/tests/test_stores.py
+++ b/packages/ingestkit-forms/tests/test_stores.py
@@ -11,6 +11,7 @@ from ingestkit_forms.models import (
     FieldType,
     FormTemplate,
     SourceFormat,
+    TemplateStatus,
 )
 from ingestkit_forms.protocols import FormTemplateStore
 from ingestkit_forms.stores.filesystem import FileSystemTemplateStore
@@ -24,6 +25,7 @@ def _make_template(
     page_count: int = 1,
     tenant_id: str | None = "tenant-a",
     layout_fingerprint: bytes | None = None,
+    status: TemplateStatus = TemplateStatus.DRAFT,
 ) -> FormTemplate:
     """Factory for FormTemplate test instances."""
     return FormTemplate(
@@ -43,6 +45,7 @@ def _make_template(
         ],
         tenant_id=tenant_id,
         layout_fingerprint=layout_fingerprint,
+        status=status,
     )
 
 
@@ -199,12 +202,14 @@ class TestFileSystemTemplateStore:
             _make_template(
                 template_id="tmpl-001",
                 layout_fingerprint=b"\x00\x01\x02\x03",
+                status=TemplateStatus.APPROVED,
             )
         )
         store.save_template(
             _make_template(
                 template_id="tmpl-002",
                 layout_fingerprint=None,
+                status=TemplateStatus.APPROVED,
             )
         )
 
@@ -222,6 +227,7 @@ class TestFileSystemTemplateStore:
                 template_id="tmpl-001",
                 tenant_id="tenant-a",
                 layout_fingerprint=b"\x00\x01",
+                status=TemplateStatus.APPROVED,
             )
         )
         store.save_template(
@@ -229,6 +235,7 @@ class TestFileSystemTemplateStore:
                 template_id="tmpl-002",
                 tenant_id="tenant-b",
                 layout_fingerprint=b"\x02\x03",
+                status=TemplateStatus.APPROVED,
             )
         )
 


### PR DESCRIPTION
## Summary
- **Issue #98**: Add `TemplateStatus` enum (DRAFT/APPROVED/ARCHIVED) with lifecycle fields (`status`, `approved_by`, `approved_at`), `approve_template()` API method, and status-aware CRUD (field changes reset to DRAFT, metadata changes preserve status, delete archives first)
- **Issue #99**: Add `status` parameter to `list_templates()` protocol + stores, make `get_all_fingerprints()` return only approved templates for matcher consumption
- **Issue #100**: Add `FieldMapping.sensitive` and `ExtractedField.redacted` boolean flags, update `redact_extraction()` to set `redacted=True` only when a pattern actually matches

## Changes
- `models.py` — `TemplateStatus` enum, lifecycle fields, `sensitive`, `redacted`, `initial_status`
- `api.py` — Lifecycle CRUD logic, `approve_template()`, status passthrough to `list_templates()`
- `dual_writer.py` — Redaction flag tracking in `redact_extraction()`
- `protocols.py` — `status` parameter on `FormTemplateStore.list_templates()`
- `stores/filesystem.py` — Status filtering in `list_templates()`, approved-only `get_all_fingerprints()`
- 12 files changed, 578 insertions, 9 deletions

## Test plan
- [x] 551 tests passing (0 failures)
- [x] New tests for `TemplateStatus` enum values and defaults
- [x] `approve_template()` tested: happy path, not found, already approved, archived
- [x] Status-aware update tested: field change resets, metadata preserves, page_count resets
- [x] Create with `initial_status` tested: default draft, approved, invalid
- [x] Delete archive behavior tested
- [x] Approved-only filtering tested: status filter, fingerprints, no filter
- [x] Redaction flag tested: set on match, not set when no match, raw_value handling
- [x] Existing matcher/store tests updated for approved-only fingerprints

Closes #98, #99, #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)